### PR TITLE
A little more robust Oracle failover

### DIFF
--- a/modules/core/pom.xml
+++ b/modules/core/pom.xml
@@ -112,5 +112,11 @@
 			<artifactId>commons-io</artifactId>
 			<scope>test</scope>
 		</dependency>
+    <dependency>
+      <groupId>org.apache.curator</groupId>
+      <artifactId>curator-test</artifactId>
+      <version>${curator.version}</version>
+      <scope>test</scope>
+    </dependency>
 	</dependencies>
 </project>

--- a/modules/core/src/main/java/accismus/impl/support/CuratorCnxnListener.java
+++ b/modules/core/src/main/java/accismus/impl/support/CuratorCnxnListener.java
@@ -1,0 +1,22 @@
+package accismus.impl.support;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.state.ConnectionState;
+import org.apache.curator.framework.state.ConnectionStateListener;
+
+public class CuratorCnxnListener implements ConnectionStateListener{
+
+	private boolean isConnected;
+
+	public synchronized boolean isConnected() {
+		return isConnected;
+	}
+
+	@Override public void stateChanged(CuratorFramework curatorFramework, ConnectionState connectionState) {
+		if(connectionState.equals(ConnectionState.CONNECTED) || connectionState.equals(ConnectionState.RECONNECTED))
+			isConnected = true;
+
+		else if(connectionState.equals(ConnectionState.LOST) || connectionState.equals(ConnectionState.SUSPENDED))
+			isConnected = false;
+	}
+}

--- a/modules/core/src/test/java/accismus/impl/AccismusIT.java
+++ b/modules/core/src/test/java/accismus/impl/AccismusIT.java
@@ -1,14 +1,5 @@
 package accismus.impl;
 
-import java.util.HashSet;
-
-import org.apache.accumulo.core.data.ArrayByteSequence;
-import org.apache.accumulo.core.data.Range;
-import org.apache.accumulo.core.security.Authorizations;
-import org.apache.accumulo.core.security.ColumnVisibility;
-import org.junit.Assert;
-import org.junit.Test;
-
 import accismus.api.Column;
 import accismus.api.ColumnIterator;
 import accismus.api.RowIterator;
@@ -19,6 +10,14 @@ import accismus.api.exceptions.CommitException;
 import accismus.api.types.StringEncoder;
 import accismus.api.types.TypeLayer;
 import accismus.impl.TransactionImpl.CommitData;
+import org.apache.accumulo.core.data.ArrayByteSequence;
+import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.security.Authorizations;
+import org.apache.accumulo.core.security.ColumnVisibility;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashSet;
 
 public class AccismusIT extends Base {
   
@@ -72,6 +71,8 @@ public class AccismusIT extends Base {
     Assert.assertEquals("5", tx3.get().row("bob").col(balanceCol).toString());
     Assert.assertEquals("20", tx3.get().row("joe").col(balanceCol).toString());
     Assert.assertEquals("65", tx3.get().row("jill").col(balanceCol).toString());
+
+
   }
   
   private void assertCommitFails(TestTransaction tx) {

--- a/modules/core/src/test/java/accismus/impl/Base.java
+++ b/modules/core/src/test/java/accismus/impl/Base.java
@@ -16,14 +16,13 @@
  */
 package accismus.impl;
 
-import java.io.File;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
-
+import accismus.api.Admin;
+import accismus.api.Column;
+import accismus.api.Observer;
+import accismus.api.config.InitializationProperties;
+import accismus.api.config.ObserverConfiguration;
+import accismus.api.config.OracleProperties;
+import accismus.format.AccismusFormatter;
 import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.Instance;
 import org.apache.accumulo.core.client.Scanner;
@@ -36,13 +35,13 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
 
-import accismus.api.Admin;
-import accismus.api.Column;
-import accismus.api.Observer;
-import accismus.api.config.InitializationProperties;
-import accismus.api.config.ObserverConfiguration;
-import accismus.api.config.OracleProperties;
-import accismus.format.AccismusFormatter;
+import java.io.File;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * 
@@ -56,7 +55,7 @@ public class Base {
   protected static AtomicInteger next = new AtomicInteger();
   
   protected static Instance instance;
-  
+
   protected Configuration config;
   protected Connector conn;
   protected String table;
@@ -105,12 +104,12 @@ public class Base {
 
   @Before
   public void setup() throws Exception {
-    
+
     conn = instance.getConnector("root", new PasswordToken(secret));
-    
+
     table = "table" + next.getAndIncrement();
     zkn = "/test" + next.getAndIncrement();
-    
+
     InitializationProperties initProps = new InitializationProperties();
 
     initProps.setAccumuloInstance(instance.getInstanceName());
@@ -125,7 +124,7 @@ public class Base {
     Admin.initialize(initProps);
 
     config = new Configuration(zk, zkn, conn, OracleProperties.ORACLE_DEFAULT_PORT);
-    
+
     oserver = createOracle(9913);
     oserver.start();
   }
@@ -134,12 +133,13 @@ public class Base {
     config = new Configuration(zk, zkn, conn, port);
     return new OracleServer(config);
   }
-  
+
   @After
   public void tearDown() throws Exception {
     conn.tableOperations().delete(table);
     oserver.stop();
-    config.getSharedResources().close();
+
+  config.getSharedResources().close();
   }
 
   protected void printTable() throws Exception {

--- a/modules/core/src/test/resources/log4j.properties
+++ b/modules/core/src/test/resources/log4j.properties
@@ -31,3 +31,4 @@ log4j.logger.org.apache.hadoop.util.NativeCodeLoader=ERROR
 log4j.logger.org.apache.hadoop.util.ProcessTree=WARN
 log4j.logger.org.apache.zookeeper.ClientCnxn=FATAL
 log4j.logger.org.apache.zookeeper.ZooKeeper=WARN
+log4j.logger.accismus=INFO


### PR DESCRIPTION
We'll still have edge cases for sure. This is an attempt to:
- Listen for changes to the children of the Oracle leader ZNode so that the client can quickly and pro-actively connect to a different oracle (instead of waiting until a connection fails).
- Figure out if we have lost all Oracles so that we can update our state quickly and disconnect from current Oracle while waiting for new one to register as a leader.

What this ticket does not solve:

In the past, I've run into situations where a server itself can become disconnected from Zookeeper for a short period and not automatically requeue itself for leadership when it returns. I'll cover this in a different ticket.
