### PR TITLE
Fixes #14 Drops and recreates table when if it exists during initializing only if setClearZookeepers = true in configuration.

### DIFF
--- a/modules/api/src/main/java/io/fluo/api/config/FluoConfiguration.java
+++ b/modules/api/src/main/java/io/fluo/api/config/FluoConfiguration.java
@@ -53,12 +53,12 @@ public class FluoConfiguration extends CompositeConfiguration {
   
   // Administration
   public static final String ADMIN_PREFIX = FLUO_PREFIX + ".admin";
-  public static final String ADMIN_ZOOKEEPER_CLEAR_PROP = ADMIN_PREFIX + ".zookeeper.clear";
+  public static final String ADMIN_ALLOW_REINITIALIZE_PROP = ADMIN_PREFIX + ".allow.reinitialize";
   public static final String ADMIN_ACCUMULO_TABLE_PROP = ADMIN_PREFIX + ".accumulo.table";
   public static final String ADMIN_ACCUMULO_CLASSPATH_PROP = ADMIN_PREFIX + ".accumulo.classpath";
   public static final String ADMIN_ACCUMULO_CLASSPATH_DEFAULT = "";
   public static final String ADMIN_CLASS_PROP = ADMIN_PREFIX + ".class";
-  public static final boolean ADMIN_ZOOKEEPER_CLEAR_DEFAULT = false;
+  public static final boolean ADMIN_ALLOW_REINITIALIZE_DEFAULT = false;
   public static final String ADMIN_CLASS_DEFAULT = FLUO_PREFIX + ".core.client.FluoAdminImpl";
   
   // Worker 
@@ -204,13 +204,13 @@ public class FluoConfiguration extends CompositeConfiguration {
     return getString(ADMIN_ACCUMULO_CLASSPATH_PROP, ADMIN_ACCUMULO_CLASSPATH_DEFAULT);
   }
  
-  public FluoConfiguration setClearZookeeper(boolean clear) {
-    setProperty(ADMIN_ZOOKEEPER_CLEAR_PROP, clear);
+  public FluoConfiguration setAllowReinitialize(boolean allowReinitialize) {
+    setProperty(ADMIN_ALLOW_REINITIALIZE_PROP, allowReinitialize);
     return this;
   }
   
-  public boolean getClearZookeeper() {
-    return getBoolean(ADMIN_ZOOKEEPER_CLEAR_PROP, ADMIN_ZOOKEEPER_CLEAR_DEFAULT);
+  public boolean getAllowReinitialize() {
+    return getBoolean(ADMIN_ALLOW_REINITIALIZE_PROP, ADMIN_ALLOW_REINITIALIZE_DEFAULT);
   }
   
   public FluoConfiguration setAdminClass(String adminClass) {
@@ -429,7 +429,7 @@ public class FluoConfiguration extends CompositeConfiguration {
     config.setProperty(CLIENT_ZOOKEEPER_ROOT_PROP, CLIENT_ZOOKEEPER_ROOT_DEFAULT);
     config.setProperty(CLIENT_ZOOKEEPER_TIMEOUT_PROP, CLIENT_ZOOKEEPER_TIMEOUT_DEFAULT);
     config.setProperty(CLIENT_CLASS_PROP, CLIENT_CLASS_DEFAULT);
-    config.setProperty(ADMIN_ZOOKEEPER_CLEAR_PROP, ADMIN_ZOOKEEPER_CLEAR_DEFAULT);
+    config.setProperty(ADMIN_ALLOW_REINITIALIZE_PROP, ADMIN_ALLOW_REINITIALIZE_DEFAULT);
     config.setProperty(ADMIN_CLASS_PROP, ADMIN_CLASS_DEFAULT);
     config.setProperty(WORKER_NUM_THREADS_PROP, WORKER_NUM_THREADS_DEFAULT);
     config.setProperty(WORKER_INSTANCES_PROP, WORKER_INSTANCES_DEFAULT);

--- a/modules/api/src/test/java/io/fluo/api/config/FluoConfigurationTest.java
+++ b/modules/api/src/test/java/io/fluo/api/config/FluoConfigurationTest.java
@@ -33,7 +33,7 @@ public class FluoConfigurationTest {
     Assert.assertEquals(FluoConfiguration.CLIENT_ZOOKEEPER_ROOT_DEFAULT, base.getZookeeperRoot());
     Assert.assertEquals(FluoConfiguration.CLIENT_ZOOKEEPER_TIMEOUT_DEFAULT, base.getZookeeperTimeout());
     Assert.assertEquals(FluoConfiguration.CLIENT_CLASS_DEFAULT, base.getClientClass());
-    Assert.assertEquals(FluoConfiguration.ADMIN_ZOOKEEPER_CLEAR_DEFAULT, base.getClearZookeeper());
+    Assert.assertEquals(FluoConfiguration.ADMIN_ALLOW_REINITIALIZE_DEFAULT, base.getAllowReinitialize());
     Assert.assertEquals(FluoConfiguration.ADMIN_CLASS_DEFAULT, base.getAdminClass());
     Assert.assertEquals(FluoConfiguration.ADMIN_ACCUMULO_CLASSPATH_DEFAULT, base.getAccumuloClasspath());
     Assert.assertEquals(FluoConfiguration.WORKER_NUM_THREADS_DEFAULT, base.getWorkerThreads());
@@ -76,7 +76,7 @@ public class FluoConfigurationTest {
     Assert.assertEquals("table", config.setAccumuloTable("table").getAccumuloTable());
     Assert.assertEquals("user", config.setAccumuloUser("user").getAccumuloUser());
     Assert.assertEquals("admin", config.setAdminClass("admin").getAdminClass());
-    Assert.assertTrue(config.setClearZookeeper(true).getClearZookeeper());
+    Assert.assertTrue(config.setAllowReinitialize(true).getAllowReinitialize());
     Assert.assertEquals("client", config.setClientClass("client").getClientClass());
     Assert.assertEquals(4, config.setLoaderQueueSize(4).getLoaderQueueSize());
     Assert.assertEquals(7, config.setLoaderThreads(7).getLoaderThreads());

--- a/modules/core/src/test/java/io/fluo/core/TestBaseMini.java
+++ b/modules/core/src/test/java/io/fluo/core/TestBaseMini.java
@@ -86,7 +86,7 @@ public class TestBaseMini {
     config.setAccumuloPassword(PASSWORD);
     config.setZookeeperRoot("/stress" + next.getAndIncrement());
     config.setZookeepers(miniAccumulo.getZooKeepers());
-    config.setClearZookeeper(true);
+    config.setAllowReinitialize(true);
     config.setAccumuloTable(getNextTableName());
     config.setWorkerThreads(5);
     config.setObservers(getObservers());

--- a/modules/core/src/test/java/io/fluo/core/client/FluoAdminImplIT.java
+++ b/modules/core/src/test/java/io/fluo/core/client/FluoAdminImplIT.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2014 Fluo authors (see AUTHORS)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fluo.core.client;
+
+import io.fluo.api.client.FluoAdmin;
+import io.fluo.core.TestBaseImpl;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class FluoAdminImplIT extends TestBaseImpl {
+
+  @Test
+  public void testInitializeTwiceFails() throws FluoAdmin.AlreadyInitializedException {
+
+    FluoAdmin fluoAdmin = new FluoAdminImpl(config);
+
+    config.setAllowReinitialize(true);
+
+    fluoAdmin.initialize();
+    fluoAdmin.initialize();
+
+    config.setAllowReinitialize(false);
+    try {
+      fluoAdmin.initialize();
+      fail("This should have failed");
+    } catch(FluoAdmin.AlreadyInitializedException e) { }
+
+    assertTrue(conn.tableOperations().exists(config.getAccumuloTable()));
+
+  }
+
+}

--- a/modules/distribution/src/main/config/fluo.properties
+++ b/modules/distribution/src/main/config/fluo.properties
@@ -41,7 +41,7 @@ io.fluo.client.accumulo.password=
 # ----------------
 # Clears configuration in Zookeeper if initialize is run again
 # Useful if accumulo was reinitialized
-#io.fluo.admin.zookeeper.clear=false
+#io.fluo.admin.allow.reinitialize=false
 # Accumulo table to initialize
 io.fluo.admin.accumulo.table=
 # Fluo uses iterators within Accumulo tablet servers, therefore Accumulo per


### PR DESCRIPTION
...g only if setClearZookeepers = true in configuration.

The more I thought about this, I think the best option is to drop and recreate the table when setClearZookeepers() is enabled and fail otherwise (with the table already exists exception).
