### PR TITLE
Add Accumulo API checks to checkstyle rules

### DIFF
--- a/src/main/resources/org/apache/fluo/resources/java-checkstyle.xml
+++ b/src/main/resources/org/apache/fluo/resources/java-checkstyle.xml
@@ -170,5 +170,11 @@
       <message key="name.invalidPattern" value="Method name ''{0}'' must match pattern ''{1}''."/>
     </module>
     <module name="SingleLineJavadoc"/>
+    <module name="RegexpSinglelineJava">
+      <!--check that only Accumulo public APIs are imported-->
+      <property name="format" value="import\s+org[.]apache[.]accumulo[.](?:.*[.](?:impl|thrift)[.].*|(?!core|minicluster).*|core[.](?!client|data|iterators|security[.]Authorizations|security[.]ColumnVisibility|util[.]format[.]Formatter).*|core[.]data[.](?!Key|Mutation|Value|Range|Condition|ConditionalMutation|ByteSequence|PartialKey|ColumnUpdate|ArrayByteSequence).*)" />
+      <property name="ignoreComments" value="true" />
+      <property name="message" value="Accumulo non-public classes imported" />
+    </module>
   </module>
 </module>


### PR DESCRIPTION
Prevent use of non-public Accumulo APIs being imported into Fluo
classes. This removes the need to have a separate execution of
checkstyle to do Accumulo API checks in Fluo projects.