### PR TITLE
Preserve license header comment formatting

### DIFF
--- a/src/main/resources/org/apache/fluo/resources/eclipse-formatter.xml
+++ b/src/main/resources/org/apache/fluo/resources/eclipse-formatter.xml
@@ -304,7 +304,7 @@
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_resources_in_try" value="80"/>
 <setting id="org.eclipse.jdt.core.formatter.use_tabs_only_for_leading_indentations" value="false"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_annotation" value="16"/>
-<setting id="org.eclipse.jdt.core.formatter.comment.format_header" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.format_header" value="false"/>
 <setting id="org.eclipse.jdt.core.formatter.comment.format_block_comments" value="true"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_enum_constant" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_enum_constants" value="0"/>


### PR DESCRIPTION
This change makes the formatter stop formatting header comments at the top of Java source files. This ensures the licenses are formatted in the way they are supposed to, for easier readability.