### PR TITLE
Fluo Issue #924

### DIFF
--- a/modules/api/src/main/java/org/apache/fluo/api/data/Bytes.java
+++ b/modules/api/src/main/java/org/apache/fluo/api/data/Bytes.java
@@ -211,6 +211,7 @@ public final class Bytes implements Comparable<Bytes>, Serializable {
    * differs, or one sequence runs out of byte (is shorter). A shorter sequence is considered less
    * than a longer one.
    *
+   * @since 1.2.0
    * @return comparison result
    */
   public int compareTo(byte[] bytes) {
@@ -224,9 +225,11 @@ public final class Bytes implements Comparable<Bytes>, Serializable {
    * differs, or one sequence runs out of byte (is shorter). A shorter sequence is considered less
    * than a longer one.
    *
+   * @since 1.2.0
    * @return comparison result
    */
   public int compareTo(byte[] bytes, int offset, int len) {
+    Preconditions.checkArgument(offset >= 0 && len >= 0 && offset + len <= bytes.length);
     if (this.length == this.data.length && len == bytes.length) {
 
       int res = UnsignedBytes.lexicographicalComparator().compare(this.data, bytes);
@@ -265,6 +268,7 @@ public final class Bytes implements Comparable<Bytes>, Serializable {
 
   /**
    * Returns true if this Bytes object equals another.
+   * @since 1.2.0
    */
   public boolean contentEquals(byte[] bytes) {
     return contentEquals(bytes, 0, bytes.length);
@@ -272,9 +276,10 @@ public final class Bytes implements Comparable<Bytes>, Serializable {
 
   /**
    * Returns true if this Bytes object equals another.
+   * @since 1.2.0
    */
   public boolean contentEquals(byte[] bytes, int offset, int len) {
-
+    Preconditions.checkArgument(len >= 0 && offset >= 0);
     if (length != len) {
       return false;
     }

--- a/modules/api/src/main/java/org/apache/fluo/api/data/Bytes.java
+++ b/modules/api/src/main/java/org/apache/fluo/api/data/Bytes.java
@@ -200,7 +200,7 @@ public final class Bytes implements Comparable<Bytes>, Serializable {
     if (this == other) {
       return 0;
     } else {
-      return compareTo(other.data, other.offset, other.length);
+      return compareToUnchecked(other.data, other.offset, other.length);
     }
   }
 
@@ -215,7 +215,7 @@ public final class Bytes implements Comparable<Bytes>, Serializable {
    * @return comparison result
    */
   public int compareTo(byte[] bytes) {
-    return compareTo(bytes, 0, bytes.length);
+    return compareToUnchecked(bytes, 0, bytes.length);
   }
 
   /**
@@ -225,13 +225,30 @@ public final class Bytes implements Comparable<Bytes>, Serializable {
    * differs, or one sequence runs out of byte (is shorter). A shorter sequence is considered less
    * than a longer one.
    *
+   * This method checks the arguments passed to it.
+   *
    * @since 1.2.0
    * @return comparison result
    */
   public int compareTo(byte[] bytes, int offset, int len) {
     Preconditions.checkArgument(offset >= 0 && len >= 0 && offset + len <= bytes.length);
-    if (this.length == this.data.length && len == bytes.length) {
+    return compareToUnchecked(bytes, offset, len);
+  }
 
+  /**
+   * Compares this to the passed bytes, byte by byte, returning a negative, zero, or positive result
+   * if the first sequence is less than, equal to, or greater than the second. The comparison is
+   * performed starting with the first byte of each sequence, and proceeds until a pair of bytes
+   * differs, or one sequence runs out of byte (is shorter). A shorter sequence is considered less
+   * than a longer one.
+   *
+   * This method does not check the arguments passed to it.
+   *
+   * @since 1.2.0
+   * @return comparison result
+   */
+  private int compareToUnchecked(byte[] bytes, int offset, int len) {
+    if (this.length == this.data.length && len == bytes.length) {
       int res = UnsignedBytes.lexicographicalComparator().compare(this.data, bytes);
       return UnsignedBytes.lexicographicalComparator().compare(this.data, bytes);
     } else {
@@ -239,7 +256,6 @@ public final class Bytes implements Comparable<Bytes>, Serializable {
       for (int i = this.offset, j = offset; i < minLen; i++, j++) {
         int a = (this.data[i] & 0xff);
         int b = (bytes[j] & 0xff);
-
         if (a != b) {
           return a - b;
         }
@@ -261,7 +277,7 @@ public final class Bytes implements Comparable<Bytes>, Serializable {
     if (other instanceof Bytes) {
       Bytes ob = (Bytes) other;
 
-      return contentEquals(ob.data, ob.offset, ob.length);
+      return contentEqualsUnchecked(ob.data, ob.offset, ob.length);
     }
     return false;
   }
@@ -271,20 +287,30 @@ public final class Bytes implements Comparable<Bytes>, Serializable {
    * @since 1.2.0
    */
   public boolean contentEquals(byte[] bytes) {
-    return contentEquals(bytes, 0, bytes.length);
+    return contentEqualsUnchecked(bytes, 0, bytes.length);
   }
 
   /**
    * Returns true if this Bytes object equals another.
+   * This method checks it's arguments.
    * @since 1.2.0
    */
   public boolean contentEquals(byte[] bytes, int offset, int len) {
     Preconditions.checkArgument(len >= 0 && offset >= 0 && offset + len <= bytes.length);
+    return contentEqualsUnchecked(bytes, offset, len);
+  }
+
+  /**
+   * Returns true if this Bytes object equals another.
+   * This method doesn't check it's arguments.
+   * @since 1.2.0
+   */
+  private boolean contentEqualsUnchecked(byte[] bytes, int offset, int len) {
     if (length != len) {
       return false;
     }
 
-    return compareTo(bytes, offset, len) == 0;
+    return compareToUnchecked(bytes, offset, len) == 0;
   }
 
   @Override

--- a/modules/api/src/main/java/org/apache/fluo/api/data/Bytes.java
+++ b/modules/api/src/main/java/org/apache/fluo/api/data/Bytes.java
@@ -279,7 +279,7 @@ public final class Bytes implements Comparable<Bytes>, Serializable {
    * @since 1.2.0
    */
   public boolean contentEquals(byte[] bytes, int offset, int len) {
-    Preconditions.checkArgument(len >= 0 && offset >= 0);
+    Preconditions.checkArgument(len >= 0 && offset >= 0 && offset + len <= bytes.length);
     if (length != len) {
       return false;
     }

--- a/modules/api/src/main/java/org/apache/fluo/api/data/Bytes.java
+++ b/modules/api/src/main/java/org/apache/fluo/api/data/Bytes.java
@@ -187,6 +187,24 @@ public final class Bytes implements Comparable<Bytes>, Serializable {
   }
 
   /**
+  * Compares this to the passed bytes, byte by byte, returning a negative, zero, or positive result
+  * if the first sequence is less than, equal to, or greater than the second. The comparison is
+  * performed starting with the first byte of each sequence, and proceeds until a pair of bytes
+  * differs, or one sequence runs out of byte (is shorter). A shorter sequence is considered less
+  * than a longer one.
+  *
+  * @return comparison result
+  */
+  @Override
+  public final int compareTo(Bytes other) {
+    if (this == other) {
+      return 0;
+    } else {
+      return compareTo(other.data, other.offset, other.length);
+    }
+  }
+
+  /**
    * Compares this to the passed bytes, byte by byte, returning a negative, zero, or positive result
    * if the first sequence is less than, equal to, or greater than the second. The comparison is
    * performed starting with the first byte of each sequence, and proceeds until a pair of bytes
@@ -195,23 +213,35 @@ public final class Bytes implements Comparable<Bytes>, Serializable {
    *
    * @return comparison result
    */
-  @Override
-  public final int compareTo(Bytes other) {
-    if (this == other) {
-      return 0;
-    } else if (this.length == this.data.length && other.length == other.data.length) {
-      return UnsignedBytes.lexicographicalComparator().compare(this.data, other.data);
+  public int compareTo(byte[] bytes) {
+    return compareTo(bytes, 0, bytes.length);
+  }
+
+  /**
+   * Compares this to the passed bytes, byte by byte, returning a negative, zero, or positive result
+   * if the first sequence is less than, equal to, or greater than the second. The comparison is
+   * performed starting with the first byte of each sequence, and proceeds until a pair of bytes
+   * differs, or one sequence runs out of byte (is shorter). A shorter sequence is considered less
+   * than a longer one.
+   *
+   * @return comparison result
+   */
+  public int compareTo(byte[] bytes, int offset, int len) {
+    if (this.length == this.data.length && len == bytes.length) {
+
+      int res = UnsignedBytes.lexicographicalComparator().compare(this.data, bytes);
+      return UnsignedBytes.lexicographicalComparator().compare(this.data, bytes);
     } else {
-      int minLen = Math.min(this.length, other.length);
-      for (int i = this.offset, j = other.offset; i < minLen; i++, j++) {
+      int minLen = Math.min(this.length, len);
+      for (int i = this.offset, j = offset; i < minLen; i++, j++) {
         int a = (this.data[i] & 0xff);
-        int b = (other.data[j] & 0xff);
+        int b = (bytes[j] & 0xff);
 
         if (a != b) {
           return a - b;
         }
       }
-      return this.length - other.length;
+      return this.length - len;
     }
   }
 
@@ -228,13 +258,28 @@ public final class Bytes implements Comparable<Bytes>, Serializable {
     if (other instanceof Bytes) {
       Bytes ob = (Bytes) other;
 
-      if (length != ob.length) {
-        return false;
-      }
-
-      return compareTo(ob) == 0;
+      return contentEquals(ob.data, ob.offset, ob.length);
     }
     return false;
+  }
+
+  /**
+   * Returns true if this Bytes object equals another.
+   */
+  public boolean contentEquals(byte[] bytes) {
+    return contentEquals(bytes, 0, bytes.length);
+  }
+
+  /**
+   * Returns true if this Bytes object equals another.
+   */
+  public boolean contentEquals(byte[] bytes, int offset, int len) {
+
+    if (length != len) {
+      return false;
+    }
+
+    return compareTo(bytes, offset, len) == 0;
   }
 
   @Override

--- a/modules/api/src/test/java/org/apache/fluo/api/data/BytesTest.java
+++ b/modules/api/src/test/java/org/apache/fluo/api/data/BytesTest.java
@@ -152,6 +152,21 @@ public class BytesTest {
     Assert.assertEquals(0, b1.compareTo(b3Arr));
     Assert.assertEquals(0, b1.compareTo(b1Arr));
     Assert.assertEquals(1, b1.compareTo(Bytes.EMPTY));
+
+    Bytes b4 = Bytes.of("abc");
+    byte[] b4Arr = b4.toArray();
+    Bytes b5 = Bytes.of("baz");
+    byte[] b5Arr = b5.toArray();
+    Bytes b6 = Bytes.of("ab");
+    byte[] b7Arr = Bytes.of("dabc").toArray();
+
+    Assert.assertEquals(0, b4.compareTo(b4Arr, 0, 3));
+    Assert.assertTrue(b4.compareTo(b4Arr, 1, 2) < 0);
+    Assert.assertTrue(b5.compareTo(b4Arr, 1, 2) < 0);
+    Assert.assertTrue(b5.compareTo(b5Arr, 1, 2) > 0);
+    Assert.assertTrue(b4.compareTo(b4Arr, 0, 2) > 0);
+    Assert.assertTrue(b6.compareTo(b7Arr, 1, 3) < 0);
+    Assert.assertTrue(b6.compareTo(b1Arr) > 0);
   }
 
   @Test(expected = IllegalArgumentException.class)

--- a/modules/api/src/test/java/org/apache/fluo/api/data/BytesTest.java
+++ b/modules/api/src/test/java/org/apache/fluo/api/data/BytesTest.java
@@ -109,6 +109,16 @@ public class BytesTest {
   }
 
   @Test
+  public void testContentEquals() {
+    Bytes b1 = Bytes.of("a");
+    byte[] b2 = b1.toArray();
+    Assert.assertTrue(b1.contentEquals(b2));
+
+    byte[] b3 = Bytes.of("b").toArray();
+    Assert.assertFalse(b1.contentEquals(b3));
+  }
+
+  @Test
   public void testCompare() {
     Bytes b1 = Bytes.of("a");
     Bytes b2 = Bytes.of("b");
@@ -117,6 +127,15 @@ public class BytesTest {
     Assert.assertEquals(1, b2.compareTo(b1));
     Assert.assertEquals(0, b1.compareTo(b3));
     Assert.assertEquals(0, b1.compareTo(b1));
+    Assert.assertEquals(1, b1.compareTo(Bytes.EMPTY));
+
+    byte[] b1Arr = b1.toArray();
+    byte[] b2Arr = b2.toArray();
+    byte[] b3Arr = b3.toArray();
+    Assert.assertEquals(-1, b1.compareTo(b2Arr));
+    Assert.assertEquals(1, b2.compareTo(b1Arr));
+    Assert.assertEquals(0, b1.compareTo(b3Arr));
+    Assert.assertEquals(0, b1.compareTo(b1Arr));
     Assert.assertEquals(1, b1.compareTo(Bytes.EMPTY));
   }
 

--- a/modules/api/src/test/java/org/apache/fluo/api/data/BytesTest.java
+++ b/modules/api/src/test/java/org/apache/fluo/api/data/BytesTest.java
@@ -17,6 +17,7 @@ package org.apache.fluo.api.data;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.lang.IllegalArgumentException;
 import java.nio.ByteBuffer;
 import java.nio.ReadOnlyBufferException;
 import java.nio.charset.StandardCharsets;
@@ -112,10 +113,24 @@ public class BytesTest {
   public void testContentEquals() {
     Bytes b1 = Bytes.of("a");
     byte[] b2 = b1.toArray();
-    Assert.assertTrue(b1.contentEquals(b2));
-
     byte[] b3 = Bytes.of("b").toArray();
+    Bytes b5 = Bytes.of("qwerty");
+    byte[] b6 = b5.toArray();
+    Bytes b7 = Bytes.of("");
+    byte[] b8 = b7.toArray();
+
+
+    Assert.assertTrue(b1.contentEquals(b2));
+    Assert.assertTrue(b5.contentEquals(b6));
+    Assert.assertTrue(b7.contentEquals(b8));
+
     Assert.assertFalse(b1.contentEquals(b3));
+    Assert.assertFalse(b1.contentEquals(b6));
+    Assert.assertFalse(b5.contentEquals(b2));
+    Assert.assertFalse(b1.contentEquals(b8));
+    Assert.assertFalse(b5.contentEquals(b8));
+    Assert.assertFalse(b7.contentEquals(b2));
+    Assert.assertFalse(b7.contentEquals(b6));
   }
 
   @Test
@@ -137,6 +152,30 @@ public class BytesTest {
     Assert.assertEquals(0, b1.compareTo(b3Arr));
     Assert.assertEquals(0, b1.compareTo(b1Arr));
     Assert.assertEquals(1, b1.compareTo(Bytes.EMPTY));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testCompareNegOffset() {
+    Bytes b1 = Bytes.of("abc");
+    byte[] b2 = b1.toArray();
+
+    b1.compareTo(b2, -4, 1);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testCompareNegLen() {
+    Bytes b1 = Bytes.of("abc");
+    byte[] b2 = b1.toArray();
+
+    b1.compareTo(b2, 0, -1);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testCompareBadArgs() {
+    Bytes b1 = Bytes.of("abc");
+    byte[] b2 = b1.toArray();
+
+    b1.compareTo(b2, 2, 2);
   }
 
   @Test


### PR DESCRIPTION
Created the following methods and corresponding unit tests for them: 
 public boolean contentEquals(byte[] bytes){...}
  public boolean contentEquals(byte[] bytes, int offset, int len){...}
  public int compareTo(byte[] bytes){...}
  public int compareTo(byte[] bytes, int offset, int len){...}
Refactored the following methods:
  public final int compareTo(Bytes other){...}
  public final boolean equals(Object other){...}