### PR TITLE
Skip ITs in Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@
 language: java
 jdk:
   - oraclejdk8
-script: mvn verify javadoc:jar
+script: mvn verify javadoc:jar -DskipITs
 notifications:
   irc:
     channels:


### PR DESCRIPTION
I have been seeing lots of Travis builds time out lately.  Thinking it may be best to skip ITs for the Travis build.