### PR TITLE
FLUO-942 The constructor for VisibilityCache now uses the values from…

### DIFF
--- a/modules/core/src/main/java/org/apache/fluo/core/impl/TransactorCache.java
+++ b/modules/core/src/main/java/org/apache/fluo/core/impl/TransactorCache.java
@@ -49,8 +49,9 @@ public class TransactorCache implements AutoCloseable {
   public TransactorCache(Environment env) {
 
     timeoutCache = CacheBuilder.newBuilder().maximumSize(1 << 15)
-        .expireAfterAccess(TxInfoCache.CACHE_TIMEOUT_MIN, TimeUnit.MINUTES).concurrencyLevel(10)
-        .build();
+        .expireAfterAccess(FluoConfigurationImpl.TX_INFO_CACHE_TIMEOUT_DEFAULT,
+            TimeUnit.MILLISECONDS)
+        .concurrencyLevel(10).build();
 
     this.env = env;
     cache = new PathChildrenCache(env.getSharedResources().getCurator(),

--- a/modules/core/src/main/java/org/apache/fluo/core/impl/TxInfoCache.java
+++ b/modules/core/src/main/java/org/apache/fluo/core/impl/TxInfoCache.java
@@ -26,8 +26,6 @@ import org.apache.fluo.api.data.Column;
 
 public class TxInfoCache {
 
-  static final int CACHE_TIMEOUT_MIN = 24 * 60;
-
   private static class TxStatusWeigher implements Weigher<PrimaryRowColumn, TxInfo> {
     @Override
     public int weigh(PrimaryRowColumn key, TxInfo value) {

--- a/modules/core/src/main/java/org/apache/fluo/core/impl/VisibilityCache.java
+++ b/modules/core/src/main/java/org/apache/fluo/core/impl/VisibilityCache.java
@@ -48,10 +48,10 @@ public class VisibilityCache {
 
   VisibilityCache() {
     visCache = CacheBuilder.newBuilder()
-               .expireAfterAccess(FluoConfigurationImpl.TX_INFO_CACHE_TIMEOUT_DEFAULT,
-                   TimeUnit.MILLISECONDS)
-               .maximumWeight(FluoConfigurationImpl.TX_INFO_CACHE_SIZE_DEFAULT)
-               .weigher(new VisWeigher()).concurrencyLevel(10).build();
+        .expireAfterAccess(FluoConfigurationImpl.TX_INFO_CACHE_TIMEOUT_DEFAULT,
+            TimeUnit.MILLISECONDS)
+        .maximumWeight(FluoConfigurationImpl.TX_INFO_CACHE_SIZE_DEFAULT).weigher(new VisWeigher())
+        .concurrencyLevel(10).build();
   }
 
   public ColumnVisibility getCV(Column col) {

--- a/modules/core/src/main/java/org/apache/fluo/core/impl/VisibilityCache.java
+++ b/modules/core/src/main/java/org/apache/fluo/core/impl/VisibilityCache.java
@@ -47,9 +47,11 @@ public class VisibilityCache {
   private final Cache<Bytes, ColumnVisibility> visCache;
 
   VisibilityCache() {
-    visCache =
-        CacheBuilder.newBuilder().expireAfterAccess(TxInfoCache.CACHE_TIMEOUT_MIN, TimeUnit.MINUTES)
-            .maximumWeight(10000000).weigher(new VisWeigher()).concurrencyLevel(10).build();
+    visCache = CacheBuilder.newBuilder()
+               .expireAfterAccess(FluoConfigurationImpl.TX_INFO_CACHE_TIMEOUT_DEFAULT,
+                   TimeUnit.MILLISECONDS)
+               .maximumWeight(FluoConfigurationImpl.TX_INFO_CACHE_SIZE_DEFAULT)
+               .weigher(new VisWeigher()).concurrencyLevel(10).build();
   }
 
   public ColumnVisibility getCV(Column col) {

--- a/modules/core/src/test/java/org/apache/fluo/core/impl/VisibilityCacheTest.java
+++ b/modules/core/src/test/java/org/apache/fluo/core/impl/VisibilityCacheTest.java
@@ -22,7 +22,7 @@ import org.junit.Test;
  * Basic test to ensure instantiation works
  */
 public class VisibilityCacheTest {
-  
+
   @Test
   public void testVisibilityCacheConstructor() {
     VisibilityCache cache = new VisibilityCache();

--- a/modules/core/src/test/java/org/apache/fluo/core/impl/VisibilityCacheTest.java
+++ b/modules/core/src/test/java/org/apache/fluo/core/impl/VisibilityCacheTest.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.fluo.core.impl;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Basic test to ensure instantiation works
+ */
+public class VisibilityCacheTest {
+  
+  @Test
+  public void testVisibilityCacheConstructor() {
+    VisibilityCache cache = new VisibilityCache();
+    Assert.assertNotNull("VisibilityCache failed to instantiate.", cache);
+    cache = null;
+  }
+}


### PR DESCRIPTION
… FluoConfigurationImpl. Also, an instantiation test has been included in the event that properties are invalidated in the future. This increases test coverage, which is a good thing.