### PR TITLE
FLUO-939 Make TransactorCache configurable

### DIFF
--- a/modules/core/src/main/java/org/apache/fluo/core/impl/FluoConfigurationImpl.java
+++ b/modules/core/src/main/java/org/apache/fluo/core/impl/FluoConfigurationImpl.java
@@ -104,21 +104,21 @@ public class FluoConfigurationImpl {
     return m;
   }
 
-  public static final String TX_INFO_CACHE_SIZE = FLUO_IMPL_PREFIX + ".tx.failed.cache.size.mb";
-  public static final long TX_INFO_CACHE_SIZE_DEFAULT = 10_000_000;
+  public static final String TX_INFO_CACHE_WEIGHT = FLUO_IMPL_PREFIX + ".tx.failed.cache.weight.mb";
+  public static final long TX_INFO_CACHE_WEIGHT_DEFAULT = 10_000_000;
 
   /** 
-   * Gets the txinfo cache size
+   * Gets the txinfo cache weight 
    * 
    * @param conf The FluoConfiguration
-   * @return The size of the cache value from the property value {@value #TX_INFO_CACHE_SIZE}
-   *     if it is set, else the value of the default value {@value #TX_INFO_CACHE_SIZE_DEFAULT}
+   * @return The size of the cache value from the property value {@value #TX_INFO_CACHE_WEIGHT}
+   *     if it is set, else the value of the default value {@value #TX_INFO_CACHE_WEIGHT_DEFAULT}
    */
 
-  public static long getTxInfoCacheSize(FluoConfiguration conf) {
-    long size = conf.getLong(TX_INFO_CACHE_SIZE, TX_INFO_CACHE_SIZE_DEFAULT);
+  public static long getTxInfoCacheWeight(FluoConfiguration conf) {
+    long size = conf.getLong(TX_INFO_CACHE_WEIGHT, TX_INFO_CACHE_WEIGHT_DEFAULT);
     if (size <= 0) {
-      throw new IllegalArgumentException("Cache size must be positive for " + TX_INFO_CACHE_SIZE);
+      throw new IllegalArgumentException("Cache size must be positive for " + TX_INFO_CACHE_WEIGHT);
     }
     return size;
   }
@@ -144,22 +144,23 @@ public class FluoConfigurationImpl {
     return tu.convert(millis, TimeUnit.MILLISECONDS);
   }
 
-  public static final String VISIBILITY_CACHE_SIZE = FLUO_IMPL_PREFIX + ".visibility.cache.size.mb";
-  public static final long VISIBILITY_CACHE_SIZE_DEFAULT = 10_000_000;
+  public static final String VISIBILITY_CACHE_WEIGHT =
+      FLUO_IMPL_PREFIX + ".visibility.cache.weight.mb";
+  public static final long VISIBILITY_CACHE_WEIGHT_DEFAULT = 10_000_000;
 
   /** 
-   * Gets the visibility cache size
+   * Gets the visibility cache weight
    * 
    * @param conf The FluoConfiguration
-   * @return The size of the cache value from the property value {@value #VISIBILITY_CACHE_SIZE}
-   *     if it is set, else the value of the default value {@value #VISIBILITY_CACHE_SIZE_DEFAULT}
+   * @return The size of the cache value from the property value {@value #VISIBILITY_WEIGHT_SIZE}
+   *     if it is set, else the value of the default value {@value #VISIBILITY_CACHE_WEIGHT_DEFAULT}
    */
 
-  public static long getVisibilityCacheSize(FluoConfiguration conf) {
-    long size = conf.getLong(VISIBILITY_CACHE_SIZE, VISIBILITY_CACHE_SIZE_DEFAULT);
+  public static long getVisibilityCacheWeight(FluoConfiguration conf) {
+    long size = conf.getLong(VISIBILITY_CACHE_WEIGHT, VISIBILITY_CACHE_WEIGHT_DEFAULT);
     if (size <= 0) {
       throw new IllegalArgumentException(
-          "Cache size must be positive for " + VISIBILITY_CACHE_SIZE);
+          "Cache size must be positive for " + VISIBILITY_CACHE_WEIGHT);
     }
     return size;
   }
@@ -189,31 +190,20 @@ public class FluoConfigurationImpl {
       FLUO_IMPL_PREFIX + ".transactor.cache.max.size";
   private static final long TRANSACTOR_MAX_CACHE_SIZE_DEFAULT = 32768; // this equals 2^15 
 
+  /**
+   * Gets the specified number of entries the cache can contain, this get the value
+   * of {@value #TRANSACTOR_MAX_CACHE_SIZE} if set, the default 
+   * {@value #TRANSACTOR_CACHE_TIMEOUT_DEFAULT} otherwise
+   * 
+   * @param conf The FluoConfiguartion
+   * @return The maximum number of entries permitted in this cache
+   */
+
   public static long getTransactorMaxCacheSize(FluoConfiguration conf) {
     long size = conf.getLong(TRANSACTOR_MAX_CACHE_SIZE, TRANSACTOR_MAX_CACHE_SIZE_DEFAULT);
     if (size <= 0) {
       throw new IllegalArgumentException(
           "Cache size must be positive for " + TRANSACTOR_MAX_CACHE_SIZE);
-    }
-    return size;
-  }
-
-  public static final String TRANSACTOR_CACHE_SIZE = FLUO_IMPL_PREFIX + ".transactor.cache.size.mb";
-  public static final long TRANSACTOR_CACHE_SIZE_DEFAULT = 10_000_000;
-
-  /** 
-   * Gets the transactor cache size
-   * 
-   * @param conf The FluoConfiguration
-   * @return The size of the cache value from the property value {@value #TRANSACTOR_CACHE_SIZE}
-   *     if it is set, else the value of the default value {@value #TRANSACTOR_CACHE_SIZE_DEFAULT}
-   */
-
-  public static long getTransactorCacheSize(FluoConfiguration conf) {
-    long size = conf.getLong(TRANSACTOR_CACHE_SIZE, TRANSACTOR_CACHE_SIZE_DEFAULT);
-    if (size <= 0) {
-      throw new IllegalArgumentException(
-          "Cache size must be positive for " + TRANSACTOR_CACHE_SIZE);
     }
     return size;
   }

--- a/modules/core/src/main/java/org/apache/fluo/core/impl/FluoConfigurationImpl.java
+++ b/modules/core/src/main/java/org/apache/fluo/core/impl/FluoConfigurationImpl.java
@@ -108,7 +108,7 @@ public class FluoConfigurationImpl {
   public static final long TX_INFO_CACHE_SIZE_DEFAULT = 10_000_000;
 
   /** 
-   * Gets the cache size
+   * Gets the txinfo cache size
    * 
    * @param conf The FluoConfiguration
    * @return The size of the cache value from the property value {@value #TX_INFO_CACHE_SIZE}
@@ -148,7 +148,7 @@ public class FluoConfigurationImpl {
   public static final long VISIBILITY_CACHE_SIZE_DEFAULT = 10_000_000;
 
   /** 
-   * Gets the cache size
+   * Gets the visibility cache size
    * 
    * @param conf The FluoConfiguration
    * @return The size of the cache value from the property value {@value #VISIBILITY_CACHE_SIZE}
@@ -181,6 +181,51 @@ public class FluoConfigurationImpl {
     long millis = conf.getLong(VISIBILITY_CACHE_TIMEOUT, VISIBILITY_CACHE_TIMEOUT_DEFAULT);
     if (millis <= 0) {
       throw new IllegalArgumentException("Timeout must positive for " + VISIBILITY_CACHE_TIMEOUT);
+    }
+    return tu.convert(millis, TimeUnit.MILLISECONDS);
+  }
+
+  private static final String TRANSACTOR_MAX_CACHE_SIZE = FLUO_IMPL_PREFIX + ".transactor.cache.max.size";
+  private static final long TRANSACTOR_MAX_CACHE_SIZE_DEFAULT = 32768; // this equals 2^15 
+  
+  public static long getTransactorMaxCacheSize(FluoConfiguration conf) {
+    long size = conf.getLong(TRANSACTOR_MAX_CACHE_SIZE, TRANSACTOR_MAX_CACHE_SIZE_DEFAULT);
+    if (size <= 0) {
+      throw new IllegalArgumentException(
+          "Cache size must be positive for " + TRANSACTOR_MAX_CACHE_SIZE);
+    }
+    return size;
+  }
+  
+  public static final String TRANSACTOR_CACHE_SIZE = FLUO_IMPL_PREFIX + ".transactor.cache.size.mb";
+  public static final long TRANSACTOR_CACHE_SIZE_DEFAULT = 10_000_000;
+  
+  /** 
+   * Gets the transactor cache size
+   * 
+   * @param conf The FluoConfiguration
+   * @return The size of the cache value from the property value {@value #TRANSACTOR_CACHE_SIZE}
+   *     if it is set, else the value of the default value {@value #TRANSACTOR_CACHE_SIZE_DEFAULT}
+   */
+  
+  public static long getTransactorCacheSize(FluoConfiguration conf) {
+    long size = conf.getLong(TRANSACTOR_CACHE_SIZE, TRANSACTOR_CACHE_SIZE_DEFAULT);
+    if (size <= 0) {
+      throw new IllegalArgumentException(
+          "Cache size must be positive for " + TRANSACTOR_CACHE_SIZE);
+    }
+    return size;
+  }
+  
+  public static final String TRANSACTOR_CACHE_TIMEOUT =
+      FLUO_IMPL_PREFIX + ".transactor.cache.expireTime.ms";
+
+  public static final long TRANSACTOR_CACHE_TIMEOUT_DEFAULT = 24 * 60 * 1000;
+  
+  public static long getTransactorCacheTimeout(FluoConfiguration conf, TimeUnit tu) {
+    long millis = conf.getLong(TRANSACTOR_CACHE_TIMEOUT, TRANSACTOR_CACHE_TIMEOUT_DEFAULT);
+    if (millis <= 0) {
+      throw new IllegalArgumentException("Timeout must positive for " + TRANSACTOR_CACHE_TIMEOUT);
     }
     return tu.convert(millis, TimeUnit.MILLISECONDS);
   }

--- a/modules/core/src/main/java/org/apache/fluo/core/impl/FluoConfigurationImpl.java
+++ b/modules/core/src/main/java/org/apache/fluo/core/impl/FluoConfigurationImpl.java
@@ -185,9 +185,10 @@ public class FluoConfigurationImpl {
     return tu.convert(millis, TimeUnit.MILLISECONDS);
   }
 
-  private static final String TRANSACTOR_MAX_CACHE_SIZE = FLUO_IMPL_PREFIX + ".transactor.cache.max.size";
+  private static final String TRANSACTOR_MAX_CACHE_SIZE =
+      FLUO_IMPL_PREFIX + ".transactor.cache.max.size";
   private static final long TRANSACTOR_MAX_CACHE_SIZE_DEFAULT = 32768; // this equals 2^15 
-  
+
   public static long getTransactorMaxCacheSize(FluoConfiguration conf) {
     long size = conf.getLong(TRANSACTOR_MAX_CACHE_SIZE, TRANSACTOR_MAX_CACHE_SIZE_DEFAULT);
     if (size <= 0) {
@@ -196,10 +197,10 @@ public class FluoConfigurationImpl {
     }
     return size;
   }
-  
+
   public static final String TRANSACTOR_CACHE_SIZE = FLUO_IMPL_PREFIX + ".transactor.cache.size.mb";
   public static final long TRANSACTOR_CACHE_SIZE_DEFAULT = 10_000_000;
-  
+
   /** 
    * Gets the transactor cache size
    * 
@@ -207,7 +208,7 @@ public class FluoConfigurationImpl {
    * @return The size of the cache value from the property value {@value #TRANSACTOR_CACHE_SIZE}
    *     if it is set, else the value of the default value {@value #TRANSACTOR_CACHE_SIZE_DEFAULT}
    */
-  
+
   public static long getTransactorCacheSize(FluoConfiguration conf) {
     long size = conf.getLong(TRANSACTOR_CACHE_SIZE, TRANSACTOR_CACHE_SIZE_DEFAULT);
     if (size <= 0) {
@@ -216,12 +217,12 @@ public class FluoConfigurationImpl {
     }
     return size;
   }
-  
+
   public static final String TRANSACTOR_CACHE_TIMEOUT =
       FLUO_IMPL_PREFIX + ".transactor.cache.expireTime.ms";
 
   public static final long TRANSACTOR_CACHE_TIMEOUT_DEFAULT = 24 * 60 * 1000;
-  
+
   public static long getTransactorCacheTimeout(FluoConfiguration conf, TimeUnit tu) {
     long millis = conf.getLong(TRANSACTOR_CACHE_TIMEOUT, TRANSACTOR_CACHE_TIMEOUT_DEFAULT);
     if (millis <= 0) {

--- a/modules/core/src/main/java/org/apache/fluo/core/impl/FluoConfigurationImpl.java
+++ b/modules/core/src/main/java/org/apache/fluo/core/impl/FluoConfigurationImpl.java
@@ -152,7 +152,7 @@ public class FluoConfigurationImpl {
    * Gets the visibility cache weight
    * 
    * @param conf The FluoConfiguration
-   * @return The size of the cache value from the property value {@value #VISIBILITY_WEIGHT_SIZE}
+   * @return The size of the cache value from the property value {@value #VISIBILITY_CACHE_WEIGHT}
    *     if it is set, else the value of the default value {@value #VISIBILITY_CACHE_WEIGHT_DEFAULT}
    */
 

--- a/modules/core/src/main/java/org/apache/fluo/core/impl/FluoConfigurationImpl.java
+++ b/modules/core/src/main/java/org/apache/fluo/core/impl/FluoConfigurationImpl.java
@@ -191,7 +191,7 @@ public class FluoConfigurationImpl {
   private static final long TRANSACTOR_MAX_CACHE_SIZE_DEFAULT = 32768; // this equals 2^15 
 
   /**
-   * Gets the specified number of entries the cache can contain, this get the value
+   * Gets the specified number of entries the cache can contain, this gets the value
    * of {@value #TRANSACTOR_MAX_CACHE_SIZE} if set, the default 
    * {@value #TRANSACTOR_CACHE_TIMEOUT_DEFAULT} otherwise
    * 

--- a/modules/core/src/main/java/org/apache/fluo/core/impl/TransactorCache.java
+++ b/modules/core/src/main/java/org/apache/fluo/core/impl/TransactorCache.java
@@ -25,6 +25,7 @@ import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import org.apache.curator.framework.recipes.cache.PathChildrenCache;
 import org.apache.curator.framework.recipes.cache.PathChildrenCache.StartMode;
+import org.apache.fluo.api.config.FluoConfiguration;
 import org.apache.fluo.accumulo.util.LongUtil;
 import org.apache.fluo.accumulo.util.ZookeeperPath;
 import org.slf4j.Logger;
@@ -45,11 +46,12 @@ public class TransactorCache implements AutoCloseable {
   private TcStatus status;
 
   private static final Logger log = LoggerFactory.getLogger(TransactorCache.class);
-
+ 
   public TransactorCache(Environment env) {
-
-    timeoutCache = CacheBuilder.newBuilder().maximumSize(1 << 15)
-        .expireAfterAccess(FluoConfigurationImpl.TX_INFO_CACHE_TIMEOUT_DEFAULT,
+    final FluoConfiguration conf = env.getConfiguration();
+    
+    timeoutCache = CacheBuilder.newBuilder().maximumSize(FluoConfigurationImpl.getTransactorMaxCacheSize(conf))
+        .expireAfterAccess(FluoConfigurationImpl.getTransactorCacheTimeout(conf, TimeUnit.MILLISECONDS),
             TimeUnit.MILLISECONDS)
         .concurrencyLevel(10).build();
 

--- a/modules/core/src/main/java/org/apache/fluo/core/impl/TransactorCache.java
+++ b/modules/core/src/main/java/org/apache/fluo/core/impl/TransactorCache.java
@@ -25,9 +25,9 @@ import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import org.apache.curator.framework.recipes.cache.PathChildrenCache;
 import org.apache.curator.framework.recipes.cache.PathChildrenCache.StartMode;
-import org.apache.fluo.api.config.FluoConfiguration;
 import org.apache.fluo.accumulo.util.LongUtil;
 import org.apache.fluo.accumulo.util.ZookeeperPath;
+import org.apache.fluo.api.config.FluoConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,14 +46,16 @@ public class TransactorCache implements AutoCloseable {
   private TcStatus status;
 
   private static final Logger log = LoggerFactory.getLogger(TransactorCache.class);
- 
+
   public TransactorCache(Environment env) {
     final FluoConfiguration conf = env.getConfiguration();
-    
-    timeoutCache = CacheBuilder.newBuilder().maximumSize(FluoConfigurationImpl.getTransactorMaxCacheSize(conf))
-        .expireAfterAccess(FluoConfigurationImpl.getTransactorCacheTimeout(conf, TimeUnit.MILLISECONDS),
-            TimeUnit.MILLISECONDS)
-        .concurrencyLevel(10).build();
+
+    timeoutCache =
+        CacheBuilder.newBuilder().maximumSize(FluoConfigurationImpl.getTransactorMaxCacheSize(conf))
+            .expireAfterAccess(
+                FluoConfigurationImpl.getTransactorCacheTimeout(conf, TimeUnit.MILLISECONDS),
+                TimeUnit.MILLISECONDS)
+            .concurrencyLevel(10).build();
 
     this.env = env;
     cache = new PathChildrenCache(env.getSharedResources().getCurator(),

--- a/modules/core/src/main/java/org/apache/fluo/core/impl/TxInfoCache.java
+++ b/modules/core/src/main/java/org/apache/fluo/core/impl/TxInfoCache.java
@@ -41,7 +41,7 @@ public class TxInfoCache {
     cache = CacheBuilder.newBuilder()
         .expireAfterAccess(FluoConfigurationImpl.getTxIfoCacheTimeout(conf, TimeUnit.MILLISECONDS),
             TimeUnit.MILLISECONDS)
-        .maximumWeight(FluoConfigurationImpl.getTxInfoCacheSize(conf))
+        .maximumWeight(FluoConfigurationImpl.getTxInfoCacheWeight(conf))
         .weigher(new TxStatusWeigher()).concurrencyLevel(10).build();
     this.env = env;
   }

--- a/modules/core/src/main/java/org/apache/fluo/core/impl/VisibilityCache.java
+++ b/modules/core/src/main/java/org/apache/fluo/core/impl/VisibilityCache.java
@@ -49,7 +49,8 @@ public class VisibilityCache {
 
   VisibilityCache(FluoConfiguration conf) {
     visCache = CacheBuilder.newBuilder()
-        .expireAfterAccess(FluoConfigurationImpl.getVisibilityCacheTimeout(conf, TimeUnit.MILLISECONDS),
+        .expireAfterAccess(
+            FluoConfigurationImpl.getVisibilityCacheTimeout(conf, TimeUnit.MILLISECONDS),
             TimeUnit.MILLISECONDS)
         .maximumWeight(FluoConfigurationImpl.getVisibilityCacheSize(conf)).weigher(new VisWeigher())
         .concurrencyLevel(10).build();

--- a/modules/core/src/main/java/org/apache/fluo/core/impl/VisibilityCache.java
+++ b/modules/core/src/main/java/org/apache/fluo/core/impl/VisibilityCache.java
@@ -52,8 +52,8 @@ public class VisibilityCache {
         .expireAfterAccess(
             FluoConfigurationImpl.getVisibilityCacheTimeout(conf, TimeUnit.MILLISECONDS),
             TimeUnit.MILLISECONDS)
-        .maximumWeight(FluoConfigurationImpl.getVisibilityCacheSize(conf)).weigher(new VisWeigher())
-        .concurrencyLevel(10).build();
+        .maximumWeight(FluoConfigurationImpl.getVisibilityCacheWeight(conf))
+        .weigher(new VisWeigher()).concurrencyLevel(10).build();
   }
 
   public ColumnVisibility getCV(Column col) {


### PR DESCRIPTION
@keith-turner I modified the constructor to take a configurable parameter like we have been doing. I did change the max size from the cryptic (1<<15) to 32768 for clarity, I bet the compiler will pre compute the number so there probably isn't any benefit besides readability.