### PR TITLE
Fix for FLUO-793 Modify ITs to use JUnits timeout rule

### DIFF
--- a/modules/integration/src/test/java/org/apache/fluo/integration/ITBase.java
+++ b/modules/integration/src/test/java/org/apache/fluo/integration/ITBase.java
@@ -58,6 +58,19 @@ public class ITBase {
   private static AtomicInteger tableCounter = new AtomicInteger(1);
   protected static AtomicInteger testCounter = new AtomicInteger();
 
+  private final static long JUNIT_TIMEOUT_SECONDS = 120;
+
+  /** 
+   * Gets the duration a test will run before timing out under the JUnit rule. 
+   * This value is in seconds.
+   * 
+   * @return long representation of the time in seconds
+   * @since 1.2.0
+   */
+  public static long getTestTimeout() {
+    return JUNIT_TIMEOUT_SECONDS;
+  }
+
   @BeforeClass
   public static void setUpAccumulo() throws Exception {
     instanceName = System.getProperty(IT_INSTANCE_NAME_PROP, "it-instance-default");

--- a/modules/integration/src/test/java/org/apache/fluo/integration/accumulo/TimeskippingIT.java
+++ b/modules/integration/src/test/java/org/apache/fluo/integration/accumulo/TimeskippingIT.java
@@ -32,7 +32,7 @@ import org.slf4j.LoggerFactory;
 
 public class TimeskippingIT extends ITBase {
   @Rule
-  public Timeout globalTimeout = Timeout.seconds(60);	
+  public Timeout globalTimeout = Timeout.seconds(60);
 
   private static final Logger log = LoggerFactory.getLogger(TimeskippingIT.class);
 

--- a/modules/integration/src/test/java/org/apache/fluo/integration/accumulo/TimeskippingIT.java
+++ b/modules/integration/src/test/java/org/apache/fluo/integration/accumulo/TimeskippingIT.java
@@ -24,11 +24,15 @@ import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.fluo.integration.ITBase;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class TimeskippingIT extends ITBase {
+  @Rule
+  public Timeout globalTimeout = Timeout.seconds(60);	
 
   private static final Logger log = LoggerFactory.getLogger(TimeskippingIT.class);
 

--- a/modules/integration/src/test/java/org/apache/fluo/integration/accumulo/TimeskippingIT.java
+++ b/modules/integration/src/test/java/org/apache/fluo/integration/accumulo/TimeskippingIT.java
@@ -32,7 +32,7 @@ import org.slf4j.LoggerFactory;
 
 public class TimeskippingIT extends ITBase {
   @Rule
-  public Timeout globalTimeout = Timeout.seconds(60);
+  public Timeout globalTimeout = Timeout.seconds(getTestTimeout());
 
   private static final Logger log = LoggerFactory.getLogger(TimeskippingIT.class);
 

--- a/modules/integration/src/test/java/org/apache/fluo/integration/client/FluoAdminImplIT.java
+++ b/modules/integration/src/test/java/org/apache/fluo/integration/client/FluoAdminImplIT.java
@@ -27,13 +27,17 @@ import org.apache.fluo.core.client.FluoClientImpl;
 import org.apache.fluo.core.util.CuratorUtil;
 import org.apache.fluo.integration.ITBaseImpl;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 public class FluoAdminImplIT extends ITBaseImpl {
-
+  @Rule
+  public Timeout globalTimeout = Timeout.seconds(60);
+  
   @Test
   public void testInitializeTwiceFails() throws Exception {
 

--- a/modules/integration/src/test/java/org/apache/fluo/integration/client/FluoAdminImplIT.java
+++ b/modules/integration/src/test/java/org/apache/fluo/integration/client/FluoAdminImplIT.java
@@ -37,7 +37,7 @@ import static org.junit.Assert.fail;
 public class FluoAdminImplIT extends ITBaseImpl {
   @Rule
   public Timeout globalTimeout = Timeout.seconds(60);
-  
+
   @Test
   public void testInitializeTwiceFails() throws Exception {
 

--- a/modules/integration/src/test/java/org/apache/fluo/integration/client/FluoClientIT.java
+++ b/modules/integration/src/test/java/org/apache/fluo/integration/client/FluoClientIT.java
@@ -24,9 +24,13 @@ import org.apache.fluo.integration.ITBaseImpl;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 
 public class FluoClientIT extends ITBaseImpl {
+  @Rule
+  public Timeout globalTimeout = Timeout.seconds(60);
 
   @Test
   public void testBasic() {

--- a/modules/integration/src/test/java/org/apache/fluo/integration/client/FluoClientIT.java
+++ b/modules/integration/src/test/java/org/apache/fluo/integration/client/FluoClientIT.java
@@ -30,7 +30,7 @@ import org.junit.rules.Timeout;
 
 public class FluoClientIT extends ITBaseImpl {
   @Rule
-  public Timeout globalTimeout = Timeout.seconds(60);
+  public Timeout globalTimeout = Timeout.seconds(getTestTimeout());
 
   @Test
   public void testBasic() {

--- a/modules/integration/src/test/java/org/apache/fluo/integration/client/LoaderExecutorIT.java
+++ b/modules/integration/src/test/java/org/apache/fluo/integration/client/LoaderExecutorIT.java
@@ -30,7 +30,7 @@ public class LoaderExecutorIT extends ITBaseMini {
 
   public static class BadLoader implements Loader {
     @Rule
-    public Timeout globalTimeout = Timeout.seconds(60);
+    public Timeout globalTimeout = Timeout.seconds(getTestTimeout());
 
     @Override
     public void load(TransactionBase tx, Context context) throws Exception {

--- a/modules/integration/src/test/java/org/apache/fluo/integration/client/LoaderExecutorIT.java
+++ b/modules/integration/src/test/java/org/apache/fluo/integration/client/LoaderExecutorIT.java
@@ -22,12 +22,15 @@ import org.apache.fluo.api.data.Column;
 import org.apache.fluo.api.exceptions.AlreadySetException;
 import org.apache.fluo.integration.ITBaseMini;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 
 public class LoaderExecutorIT extends ITBaseMini {
 
   public static class BadLoader implements Loader {
-
+	@Rule
+	public Timeout globalTimeout = Timeout.seconds(60);
     @Override
     public void load(TransactionBase tx, Context context) throws Exception {
       tx.set("r", new Column("f", "q"), "v");

--- a/modules/integration/src/test/java/org/apache/fluo/integration/client/LoaderExecutorIT.java
+++ b/modules/integration/src/test/java/org/apache/fluo/integration/client/LoaderExecutorIT.java
@@ -29,8 +29,9 @@ import org.junit.rules.Timeout;
 public class LoaderExecutorIT extends ITBaseMini {
 
   public static class BadLoader implements Loader {
-	@Rule
-	public Timeout globalTimeout = Timeout.seconds(60);
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(60);
+
     @Override
     public void load(TransactionBase tx, Context context) throws Exception {
       tx.set("r", new Column("f", "q"), "v");

--- a/modules/integration/src/test/java/org/apache/fluo/integration/impl/ApiBehaviorIT.java
+++ b/modules/integration/src/test/java/org/apache/fluo/integration/impl/ApiBehaviorIT.java
@@ -30,7 +30,7 @@ import org.junit.rules.Timeout;
 
 public class ApiBehaviorIT extends ITBaseImpl {
   @Rule
-  public Timeout globalTimeout = Timeout.seconds(60);
+  public Timeout globalTimeout = Timeout.seconds(getTestTimeout());
 
   @Test
   public void testGetNonexistant() {

--- a/modules/integration/src/test/java/org/apache/fluo/integration/impl/ApiBehaviorIT.java
+++ b/modules/integration/src/test/java/org/apache/fluo/integration/impl/ApiBehaviorIT.java
@@ -24,9 +24,13 @@ import org.apache.fluo.api.data.RowColumn;
 import org.apache.fluo.integration.ITBaseImpl;
 import org.apache.fluo.integration.TestTransaction;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 
 public class ApiBehaviorIT extends ITBaseImpl {
+  @Rule
+  public Timeout globalTimeout = Timeout.seconds(60);
   @Test
   public void testGetNonexistant() {
 

--- a/modules/integration/src/test/java/org/apache/fluo/integration/impl/ApiBehaviorIT.java
+++ b/modules/integration/src/test/java/org/apache/fluo/integration/impl/ApiBehaviorIT.java
@@ -31,6 +31,7 @@ import org.junit.rules.Timeout;
 public class ApiBehaviorIT extends ITBaseImpl {
   @Rule
   public Timeout globalTimeout = Timeout.seconds(60);
+
   @Test
   public void testGetNonexistant() {
 

--- a/modules/integration/src/test/java/org/apache/fluo/integration/impl/AppConfigIT.java
+++ b/modules/integration/src/test/java/org/apache/fluo/integration/impl/AppConfigIT.java
@@ -35,7 +35,7 @@ import static org.apache.fluo.api.observer.Observer.NotificationType.STRONG;
 
 public class AppConfigIT extends ITBaseMini {
   @Rule
-  public Timeout globalTimeout = Timeout.seconds(60);
+  public Timeout globalTimeout = Timeout.seconds(getTestTimeout());
   public static final Column DF_COL = new Column("data", "foo");
   public static final Column DB_COL = new Column("data", "bar");
 

--- a/modules/integration/src/test/java/org/apache/fluo/integration/impl/AppConfigIT.java
+++ b/modules/integration/src/test/java/org/apache/fluo/integration/impl/AppConfigIT.java
@@ -27,12 +27,15 @@ import org.apache.fluo.api.data.Column;
 import org.apache.fluo.api.observer.ObserverProvider;
 import org.apache.fluo.integration.ITBaseMini;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 
 import static org.apache.fluo.api.observer.Observer.NotificationType.STRONG;
 
 public class AppConfigIT extends ITBaseMini {
-
+  @Rule
+  public Timeout globalTimeout = Timeout.seconds(60);
   public static final Column DF_COL = new Column("data", "foo");
   public static final Column DB_COL = new Column("data", "bar");
 

--- a/modules/integration/src/test/java/org/apache/fluo/integration/impl/ClientExceptionIT.java
+++ b/modules/integration/src/test/java/org/apache/fluo/integration/impl/ClientExceptionIT.java
@@ -31,6 +31,7 @@ import org.junit.rules.Timeout;
 public class ClientExceptionIT extends ITBaseMini {
   @Rule
   public Timeout globalTimeout = Timeout.seconds(60);
+
   @Test
   public void testAlreadySetException() {
 

--- a/modules/integration/src/test/java/org/apache/fluo/integration/impl/ClientExceptionIT.java
+++ b/modules/integration/src/test/java/org/apache/fluo/integration/impl/ClientExceptionIT.java
@@ -21,13 +21,16 @@ import org.apache.fluo.api.data.Column;
 import org.apache.fluo.api.exceptions.AlreadySetException;
 import org.apache.fluo.integration.ITBaseMini;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 
 /**
  * Integration test to verify exceptions thrown by Fluo client
  */
 public class ClientExceptionIT extends ITBaseMini {
-
+  @Rule
+  public Timeout globalTimeout = Timeout.seconds(60);
   @Test
   public void testAlreadySetException() {
 

--- a/modules/integration/src/test/java/org/apache/fluo/integration/impl/ClientExceptionIT.java
+++ b/modules/integration/src/test/java/org/apache/fluo/integration/impl/ClientExceptionIT.java
@@ -30,7 +30,7 @@ import org.junit.rules.Timeout;
  */
 public class ClientExceptionIT extends ITBaseMini {
   @Rule
-  public Timeout globalTimeout = Timeout.seconds(60);
+  public Timeout globalTimeout = Timeout.seconds(getTestTimeout());
 
   @Test
   public void testAlreadySetException() {

--- a/modules/integration/src/test/java/org/apache/fluo/integration/impl/CollisionIT.java
+++ b/modules/integration/src/test/java/org/apache/fluo/integration/impl/CollisionIT.java
@@ -62,7 +62,7 @@ public class CollisionIT extends ITBaseMini {
   private static final Column STAT_PROCESSED = new Column("stat", "processed");
 
   @Rule
-  public Timeout globalTimeout = Timeout.seconds(60);
+  public Timeout globalTimeout = Timeout.seconds(getTestTimeout());
 
   private static class NumLoader implements Loader {
 

--- a/modules/integration/src/test/java/org/apache/fluo/integration/impl/ColumnVisIT.java
+++ b/modules/integration/src/test/java/org/apache/fluo/integration/impl/ColumnVisIT.java
@@ -21,10 +21,13 @@ import com.google.common.collect.Sets;
 import org.apache.fluo.api.data.Column;
 import org.apache.fluo.integration.ITBaseImpl;
 import org.apache.fluo.integration.TestTransaction;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 
 public class ColumnVisIT extends ITBaseImpl {
-
+  @Rule
+  public Timeout globalTimeout = Timeout.seconds(60);
   @Test(expected = Exception.class)
   public void testFailFastSet() {
     TestTransaction tx1 = new TestTransaction(env);

--- a/modules/integration/src/test/java/org/apache/fluo/integration/impl/ColumnVisIT.java
+++ b/modules/integration/src/test/java/org/apache/fluo/integration/impl/ColumnVisIT.java
@@ -27,7 +27,7 @@ import org.junit.rules.Timeout;
 
 public class ColumnVisIT extends ITBaseImpl {
   @Rule
-  public Timeout globalTimeout = Timeout.seconds(60);
+  public Timeout globalTimeout = Timeout.seconds(getTestTimeout());
 
   @Test(expected = Exception.class)
   public void testFailFastSet() {

--- a/modules/integration/src/test/java/org/apache/fluo/integration/impl/ColumnVisIT.java
+++ b/modules/integration/src/test/java/org/apache/fluo/integration/impl/ColumnVisIT.java
@@ -28,6 +28,7 @@ import org.junit.rules.Timeout;
 public class ColumnVisIT extends ITBaseImpl {
   @Rule
   public Timeout globalTimeout = Timeout.seconds(60);
+
   @Test(expected = Exception.class)
   public void testFailFastSet() {
     TestTransaction tx1 = new TestTransaction(env);

--- a/modules/integration/src/test/java/org/apache/fluo/integration/impl/FailureIT.java
+++ b/modules/integration/src/test/java/org/apache/fluo/integration/impl/FailureIT.java
@@ -58,7 +58,7 @@ import static org.apache.fluo.integration.BankUtil.BALANCE;
 
 public class FailureIT extends ITBaseImpl {
   @Rule
-  public Timeout globalTimeout = Timeout.seconds(60);
+  public Timeout globalTimeout = Timeout.seconds(getTestTimeout());
   @Rule
   public ExpectedException exception = ExpectedException.none();
 

--- a/modules/integration/src/test/java/org/apache/fluo/integration/impl/FailureIT.java
+++ b/modules/integration/src/test/java/org/apache/fluo/integration/impl/FailureIT.java
@@ -51,12 +51,14 @@ import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.junit.rules.Timeout;
 
 import static org.apache.fluo.api.observer.Observer.NotificationType.STRONG;
 import static org.apache.fluo.integration.BankUtil.BALANCE;
 
 public class FailureIT extends ITBaseImpl {
-
+  @Rule
+  public Timeout globalTimeout = Timeout.seconds(60);
   @Rule
   public ExpectedException exception = ExpectedException.none();
 

--- a/modules/integration/src/test/java/org/apache/fluo/integration/impl/FaultyConfig.java
+++ b/modules/integration/src/test/java/org/apache/fluo/integration/impl/FaultyConfig.java
@@ -37,7 +37,7 @@ public class FaultyConfig extends Environment {
    * module.
    */
   private static class FaultyConditionalWriter implements ConditionalWriter {
-    
+
     private ConditionalWriter cw;
     private double up;
     private Random rand;

--- a/modules/integration/src/test/java/org/apache/fluo/integration/impl/FaultyConfig.java
+++ b/modules/integration/src/test/java/org/apache/fluo/integration/impl/FaultyConfig.java
@@ -37,7 +37,7 @@ public class FaultyConfig extends Environment {
    * module.
    */
   private static class FaultyConditionalWriter implements ConditionalWriter {
-
+    
     private ConditionalWriter cw;
     private double up;
     private Random rand;

--- a/modules/integration/src/test/java/org/apache/fluo/integration/impl/FluoIT.java
+++ b/modules/integration/src/test/java/org/apache/fluo/integration/impl/FluoIT.java
@@ -52,6 +52,7 @@ import static org.apache.fluo.integration.BankUtil.BALANCE;
 public class FluoIT extends ITBaseImpl {
   @Rule
   public Timeout globalTimeout = Timeout.seconds(60);
+
   public static class FluoITObserverProvider implements ObserverProvider {
     @Override
     public void provide(Registry or, Context ctx) {

--- a/modules/integration/src/test/java/org/apache/fluo/integration/impl/FluoIT.java
+++ b/modules/integration/src/test/java/org/apache/fluo/integration/impl/FluoIT.java
@@ -51,7 +51,7 @@ import static org.apache.fluo.integration.BankUtil.BALANCE;
 
 public class FluoIT extends ITBaseImpl {
   @Rule
-  public Timeout globalTimeout = Timeout.seconds(60);
+  public Timeout globalTimeout = Timeout.seconds(getTestTimeout());
 
   public static class FluoITObserverProvider implements ObserverProvider {
     @Override

--- a/modules/integration/src/test/java/org/apache/fluo/integration/impl/FluoIT.java
+++ b/modules/integration/src/test/java/org/apache/fluo/integration/impl/FluoIT.java
@@ -32,7 +32,6 @@ import org.apache.fluo.api.config.FluoConfiguration;
 import org.apache.fluo.api.data.Bytes;
 import org.apache.fluo.api.data.Column;
 import org.apache.fluo.api.data.RowColumnValue;
-import org.apache.fluo.api.data.Span;
 import org.apache.fluo.api.exceptions.CommitException;
 import org.apache.fluo.api.observer.Observer.NotificationType;
 import org.apache.fluo.api.observer.ObserverProvider;
@@ -44,12 +43,15 @@ import org.apache.fluo.integration.ITBaseImpl;
 import org.apache.fluo.integration.TestTransaction;
 import org.apache.fluo.integration.TestUtil;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 
 import static org.apache.fluo.integration.BankUtil.BALANCE;
 
 public class FluoIT extends ITBaseImpl {
-
+  @Rule
+  public Timeout globalTimeout = Timeout.seconds(60);
   public static class FluoITObserverProvider implements ObserverProvider {
     @Override
     public void provide(Registry or, Context ctx) {

--- a/modules/integration/src/test/java/org/apache/fluo/integration/impl/GarbageCollectionIteratorIT.java
+++ b/modules/integration/src/test/java/org/apache/fluo/integration/impl/GarbageCollectionIteratorIT.java
@@ -38,13 +38,16 @@ import org.apache.fluo.integration.TestTransaction;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 
 /**
  * Tests GarbageCollectionIterator class
  */
 public class GarbageCollectionIteratorIT extends ITBaseImpl {
-
+  @Rule
+  public Timeout globalTimeout = Timeout.seconds(60);
   private void waitForGcTime(long expectedTime) throws Exception {
     env.getSharedResources().getTimestampTracker().updateZkNode();
     long oldestTs = ZookeeperUtil.getGcTimestamp(config.getAppZookeepers());
@@ -54,7 +57,7 @@ public class GarbageCollectionIteratorIT extends ITBaseImpl {
     }
   }
 
-  @Test(timeout = 60000)
+
   public void testVerifyAfterGC() throws Exception {
 
     TestTransaction tx1 = new TestTransaction(env);
@@ -87,7 +90,7 @@ public class GarbageCollectionIteratorIT extends ITBaseImpl {
     tx2.done();
   }
 
-  @Test(timeout = 60000)
+
   public void testDeletedDataIsDropped() throws Exception {
 
     final Column docUri = new Column("doc", "uri");
@@ -126,7 +129,7 @@ public class GarbageCollectionIteratorIT extends ITBaseImpl {
     tx4.done();
   }
 
-  @Test(timeout = 60000)
+
   public void testRolledBackDataIsDropped() throws Exception {
 
     Column col1 = new Column("fam1", "q1");

--- a/modules/integration/src/test/java/org/apache/fluo/integration/impl/GarbageCollectionIteratorIT.java
+++ b/modules/integration/src/test/java/org/apache/fluo/integration/impl/GarbageCollectionIteratorIT.java
@@ -47,7 +47,7 @@ import org.junit.rules.Timeout;
  */
 public class GarbageCollectionIteratorIT extends ITBaseImpl {
   @Rule
-  public Timeout globalTimeout = Timeout.seconds(60);
+  public Timeout globalTimeout = Timeout.seconds(getTestTimeout());
 
   private void waitForGcTime(long expectedTime) throws Exception {
     env.getSharedResources().getTimestampTracker().updateZkNode();

--- a/modules/integration/src/test/java/org/apache/fluo/integration/impl/GarbageCollectionIteratorIT.java
+++ b/modules/integration/src/test/java/org/apache/fluo/integration/impl/GarbageCollectionIteratorIT.java
@@ -48,6 +48,7 @@ import org.junit.rules.Timeout;
 public class GarbageCollectionIteratorIT extends ITBaseImpl {
   @Rule
   public Timeout globalTimeout = Timeout.seconds(60);
+
   private void waitForGcTime(long expectedTime) throws Exception {
     env.getSharedResources().getTimestampTracker().updateZkNode();
     long oldestTs = ZookeeperUtil.getGcTimestamp(config.getAppZookeepers());

--- a/modules/integration/src/test/java/org/apache/fluo/integration/impl/MiniIT.java
+++ b/modules/integration/src/test/java/org/apache/fluo/integration/impl/MiniIT.java
@@ -27,13 +27,16 @@ import org.apache.fluo.api.data.Bytes;
 import org.apache.fluo.api.data.Column;
 import org.apache.fluo.api.mini.MiniFluo;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 
 /**
  * Tests MiniFluo
  */
 public class MiniIT {
-
+  @Rule
+  public Timeout globalTimeout = Timeout.seconds(60);
   @Test
   public void testMini() throws Exception {
     File dataDir =

--- a/modules/integration/src/test/java/org/apache/fluo/integration/impl/MiniIT.java
+++ b/modules/integration/src/test/java/org/apache/fluo/integration/impl/MiniIT.java
@@ -37,6 +37,7 @@ import org.junit.rules.Timeout;
 public class MiniIT {
   @Rule
   public Timeout globalTimeout = Timeout.seconds(60);
+
   @Test
   public void testMini() throws Exception {
     File dataDir =

--- a/modules/integration/src/test/java/org/apache/fluo/integration/impl/MiniIT.java
+++ b/modules/integration/src/test/java/org/apache/fluo/integration/impl/MiniIT.java
@@ -26,6 +26,7 @@ import org.apache.fluo.api.config.FluoConfiguration;
 import org.apache.fluo.api.data.Bytes;
 import org.apache.fluo.api.data.Column;
 import org.apache.fluo.api.mini.MiniFluo;
+import org.apache.fluo.integration.ITBase;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -36,7 +37,7 @@ import org.junit.rules.Timeout;
  */
 public class MiniIT {
   @Rule
-  public Timeout globalTimeout = Timeout.seconds(60);
+  public Timeout globalTimeout = Timeout.seconds(ITBase.getTestTimeout());
 
   @Test
   public void testMini() throws Exception {

--- a/modules/integration/src/test/java/org/apache/fluo/integration/impl/NotificationGcIT.java
+++ b/modules/integration/src/test/java/org/apache/fluo/integration/impl/NotificationGcIT.java
@@ -39,7 +39,7 @@ import org.slf4j.LoggerFactory;
 
 public class NotificationGcIT extends ITBaseMini {
   @Rule
-  public Timeout globalTimeout = Timeout.seconds(60);
+  public Timeout globalTimeout = Timeout.seconds(getTestTimeout());
   private static final Logger log = LoggerFactory.getLogger(NotificationGcIT.class);
 
   private static void assertRawNotifications(int expected, Environment env) throws Exception {

--- a/modules/integration/src/test/java/org/apache/fluo/integration/impl/NotificationGcIT.java
+++ b/modules/integration/src/test/java/org/apache/fluo/integration/impl/NotificationGcIT.java
@@ -31,12 +31,15 @@ import org.apache.fluo.integration.ITBaseMini;
 import org.apache.fluo.integration.TestTransaction;
 import org.apache.fluo.integration.impl.WeakNotificationIT.WeakNotificationITObserverProvider;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class NotificationGcIT extends ITBaseMini {
-
+  @Rule
+  public Timeout globalTimeout = Timeout.seconds(60);
   private static final Logger log = LoggerFactory.getLogger(NotificationGcIT.class);
 
   private static void assertRawNotifications(int expected, Environment env) throws Exception {

--- a/modules/integration/src/test/java/org/apache/fluo/integration/impl/ObserverConfigIT.java
+++ b/modules/integration/src/test/java/org/apache/fluo/integration/impl/ObserverConfigIT.java
@@ -43,7 +43,7 @@ public class ObserverConfigIT extends ITBaseMini {
 
   public static class ConfigurableObserver extends AbstractObserver {
     @Rule
-    public Timeout globalTimeout = Timeout.seconds(60);
+    public Timeout globalTimeout = Timeout.seconds(getTestTimeout());
 
     private ObservedColumn observedColumn;
     private Bytes outputCQ;

--- a/modules/integration/src/test/java/org/apache/fluo/integration/impl/ObserverConfigIT.java
+++ b/modules/integration/src/test/java/org/apache/fluo/integration/impl/ObserverConfigIT.java
@@ -34,12 +34,16 @@ import org.apache.fluo.api.observer.AbstractObserver;
 import org.apache.fluo.api.observer.Observer.NotificationType;
 import org.apache.fluo.integration.ITBaseMini;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 
 @Deprecated
 public class ObserverConfigIT extends ITBaseMini {
 
   public static class ConfigurableObserver extends AbstractObserver {
+  @Rule
+  public Timeout globalTimeout = Timeout.seconds(60);
 
     private ObservedColumn observedColumn;
     private Bytes outputCQ;

--- a/modules/integration/src/test/java/org/apache/fluo/integration/impl/ObserverConfigIT.java
+++ b/modules/integration/src/test/java/org/apache/fluo/integration/impl/ObserverConfigIT.java
@@ -42,8 +42,8 @@ import org.junit.rules.Timeout;
 public class ObserverConfigIT extends ITBaseMini {
 
   public static class ConfigurableObserver extends AbstractObserver {
-  @Rule
-  public Timeout globalTimeout = Timeout.seconds(60);
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(60);
 
     private ObservedColumn observedColumn;
     private Bytes outputCQ;

--- a/modules/integration/src/test/java/org/apache/fluo/integration/impl/OracleIT.java
+++ b/modules/integration/src/test/java/org/apache/fluo/integration/impl/OracleIT.java
@@ -47,7 +47,7 @@ import static org.junit.Assert.assertTrue;
 public class OracleIT extends ITBaseImpl {
 
   @Rule
-  public Timeout globalTimeout = Timeout.seconds(60);
+  public Timeout globalTimeout = Timeout.seconds(getTestTimeout());
 
   @Test
   public void testRestart() throws Exception {

--- a/modules/integration/src/test/java/org/apache/fluo/integration/impl/ParallelScannerIT.java
+++ b/modules/integration/src/test/java/org/apache/fluo/integration/impl/ParallelScannerIT.java
@@ -35,7 +35,7 @@ import org.junit.rules.Timeout;
 
 public class ParallelScannerIT extends ITBaseImpl {
   @Rule
-  public Timeout globalTimeout = Timeout.seconds(60);
+  public Timeout globalTimeout = Timeout.seconds(getTestTimeout());
 
   @Test
   public void testRowColumn() {

--- a/modules/integration/src/test/java/org/apache/fluo/integration/impl/ParallelScannerIT.java
+++ b/modules/integration/src/test/java/org/apache/fluo/integration/impl/ParallelScannerIT.java
@@ -36,6 +36,7 @@ import org.junit.rules.Timeout;
 public class ParallelScannerIT extends ITBaseImpl {
   @Rule
   public Timeout globalTimeout = Timeout.seconds(60);
+
   @Test
   public void testRowColumn() {
     TestTransaction tx1 = new TestTransaction(env);

--- a/modules/integration/src/test/java/org/apache/fluo/integration/impl/ParallelScannerIT.java
+++ b/modules/integration/src/test/java/org/apache/fluo/integration/impl/ParallelScannerIT.java
@@ -29,10 +29,13 @@ import org.apache.fluo.core.oracle.Stamp;
 import org.apache.fluo.integration.ITBaseImpl;
 import org.apache.fluo.integration.TestTransaction;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 
 public class ParallelScannerIT extends ITBaseImpl {
-
+  @Rule
+  public Timeout globalTimeout = Timeout.seconds(60);
   @Test
   public void testRowColumn() {
     TestTransaction tx1 = new TestTransaction(env);

--- a/modules/integration/src/test/java/org/apache/fluo/integration/impl/ScannerIT.java
+++ b/modules/integration/src/test/java/org/apache/fluo/integration/impl/ScannerIT.java
@@ -37,7 +37,7 @@ import org.junit.rules.Timeout;
 
 public class ScannerIT extends ITBaseImpl {
   @Rule
-  public Timeout globalTimeout = Timeout.seconds(60);
+  public Timeout globalTimeout = Timeout.seconds(getTestTimeout());
 
   @Test
   public void testFiltering() {

--- a/modules/integration/src/test/java/org/apache/fluo/integration/impl/ScannerIT.java
+++ b/modules/integration/src/test/java/org/apache/fluo/integration/impl/ScannerIT.java
@@ -29,12 +29,15 @@ import org.apache.fluo.api.data.Bytes;
 import org.apache.fluo.api.data.Column;
 import org.apache.fluo.api.data.ColumnValue;
 import org.apache.fluo.api.data.RowColumnValue;
-import org.apache.fluo.api.data.Span;
 import org.apache.fluo.integration.ITBaseImpl;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 
 public class ScannerIT extends ITBaseImpl {
+  @Rule
+  public Timeout globalTimeout = Timeout.seconds(60);
 
   @Test
   public void testFiltering() {

--- a/modules/integration/src/test/java/org/apache/fluo/integration/impl/SelfNotificationIT.java
+++ b/modules/integration/src/test/java/org/apache/fluo/integration/impl/SelfNotificationIT.java
@@ -28,7 +28,9 @@ import org.apache.fluo.api.observer.Observer;
 import org.apache.fluo.api.observer.ObserverProvider;
 import org.apache.fluo.integration.ITBaseMini;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 
 import static org.apache.fluo.api.observer.Observer.NotificationType.STRONG;
 
@@ -36,6 +38,8 @@ import static org.apache.fluo.api.observer.Observer.NotificationType.STRONG;
  * Test an observer notifying the column its observing. This is a useful pattern for exporting data.
  */
 public class SelfNotificationIT extends ITBaseMini {
+  @Rule
+  public Timeout globalTimeout = Timeout.seconds(60);
 
   private static final Column STAT_COUNT_COL = new Column("stat", "count");
   private static final Column EXPORT_CHECK_COL = new Column("export", "check");

--- a/modules/integration/src/test/java/org/apache/fluo/integration/impl/SelfNotificationIT.java
+++ b/modules/integration/src/test/java/org/apache/fluo/integration/impl/SelfNotificationIT.java
@@ -39,7 +39,7 @@ import static org.apache.fluo.api.observer.Observer.NotificationType.STRONG;
  */
 public class SelfNotificationIT extends ITBaseMini {
   @Rule
-  public Timeout globalTimeout = Timeout.seconds(60);
+  public Timeout globalTimeout = Timeout.seconds(getTestTimeout());
 
   private static final Column STAT_COUNT_COL = new Column("stat", "count");
   private static final Column EXPORT_CHECK_COL = new Column("export", "check");

--- a/modules/integration/src/test/java/org/apache/fluo/integration/impl/StochasticBankIT.java
+++ b/modules/integration/src/test/java/org/apache/fluo/integration/impl/StochasticBankIT.java
@@ -53,8 +53,8 @@ import org.slf4j.LoggerFactory;
  * sum of all money in the bank should be the same, therefore the average should not vary.
  */
 public class StochasticBankIT extends ITBaseImpl {
-  //@Rule
-  //public Timeout globalTimeout = Timeout.seconds(120);
+  @Rule
+  public Timeout globalTimeout = Timeout.seconds(120);
 
   private static final Logger log = LoggerFactory.getLogger(StochasticBankIT.class);
   private static AtomicInteger txCount = new AtomicInteger();

--- a/modules/integration/src/test/java/org/apache/fluo/integration/impl/StochasticBankIT.java
+++ b/modules/integration/src/test/java/org/apache/fluo/integration/impl/StochasticBankIT.java
@@ -54,7 +54,7 @@ import org.slf4j.LoggerFactory;
  */
 public class StochasticBankIT extends ITBaseImpl {
   @Rule
-  public Timeout globalTimeout = Timeout.seconds(120);
+  public Timeout globalTimeout = Timeout.seconds(getTestTimeout() * 2);
 
   private static final Logger log = LoggerFactory.getLogger(StochasticBankIT.class);
   private static AtomicInteger txCount = new AtomicInteger();

--- a/modules/integration/src/test/java/org/apache/fluo/integration/impl/StochasticBankIT.java
+++ b/modules/integration/src/test/java/org/apache/fluo/integration/impl/StochasticBankIT.java
@@ -42,7 +42,9 @@ import org.apache.fluo.integration.ITBaseImpl;
 import org.apache.fluo.integration.TestTransaction;
 import org.apache.hadoop.io.Text;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -51,6 +53,8 @@ import org.slf4j.LoggerFactory;
  * sum of all money in the bank should be the same, therefore the average should not vary.
  */
 public class StochasticBankIT extends ITBaseImpl {
+  //@Rule
+  //public Timeout globalTimeout = Timeout.seconds(120);
 
   private static final Logger log = LoggerFactory.getLogger(StochasticBankIT.class);
   private static AtomicInteger txCount = new AtomicInteger();

--- a/modules/integration/src/test/java/org/apache/fluo/integration/impl/StrongNotificationIT.java
+++ b/modules/integration/src/test/java/org/apache/fluo/integration/impl/StrongNotificationIT.java
@@ -33,7 +33,7 @@ import static org.apache.fluo.api.observer.Observer.NotificationType.STRONG;
 
 public class StrongNotificationIT extends ITBaseMini {
   @Rule
-  public Timeout globalTimeout = Timeout.seconds(60);
+  public Timeout globalTimeout = Timeout.seconds(getTestTimeout());
 
   private static final Column OC = new Column("f", "q");
   private static final Column RC = new Column("f", "r");

--- a/modules/integration/src/test/java/org/apache/fluo/integration/impl/StrongNotificationIT.java
+++ b/modules/integration/src/test/java/org/apache/fluo/integration/impl/StrongNotificationIT.java
@@ -25,11 +25,15 @@ import org.apache.fluo.core.impl.TransactorNode;
 import org.apache.fluo.integration.ITBaseMini;
 import org.apache.fluo.integration.TestTransaction;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 
 import static org.apache.fluo.api.observer.Observer.NotificationType.STRONG;
 
 public class StrongNotificationIT extends ITBaseMini {
+  @Rule
+  public Timeout globalTimeout = Timeout.seconds(60);
 
   private static final Column OC = new Column("f", "q");
   private static final Column RC = new Column("f", "r");

--- a/modules/integration/src/test/java/org/apache/fluo/integration/impl/TimestampTrackerIT.java
+++ b/modules/integration/src/test/java/org/apache/fluo/integration/impl/TimestampTrackerIT.java
@@ -37,6 +37,7 @@ import org.junit.rules.Timeout;
 public class TimestampTrackerIT extends ITBaseImpl {
   @Rule
   public Timeout globalTimeout = Timeout.seconds(60);
+
   @Test(expected = NoSuchElementException.class)
   public void testTsNoElement() {
     TimestampTracker tracker = env.getSharedResources().getTimestampTracker();

--- a/modules/integration/src/test/java/org/apache/fluo/integration/impl/TimestampTrackerIT.java
+++ b/modules/integration/src/test/java/org/apache/fluo/integration/impl/TimestampTrackerIT.java
@@ -27,13 +27,16 @@ import org.apache.fluo.core.impl.TransactorID;
 import org.apache.fluo.integration.ITBaseImpl;
 import org.apache.zookeeper.KeeperException.NoNodeException;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 
 /**
  * Tests TimestampTracker class
  */
 public class TimestampTrackerIT extends ITBaseImpl {
-
+  @Rule
+  public Timeout globalTimeout = Timeout.seconds(60);
   @Test(expected = NoSuchElementException.class)
   public void testTsNoElement() {
     TimestampTracker tracker = env.getSharedResources().getTimestampTracker();

--- a/modules/integration/src/test/java/org/apache/fluo/integration/impl/TimestampTrackerIT.java
+++ b/modules/integration/src/test/java/org/apache/fluo/integration/impl/TimestampTrackerIT.java
@@ -36,7 +36,7 @@ import org.junit.rules.Timeout;
  */
 public class TimestampTrackerIT extends ITBaseImpl {
   @Rule
-  public Timeout globalTimeout = Timeout.seconds(60);
+  public Timeout globalTimeout = Timeout.seconds(getTestTimeout());
 
   @Test(expected = NoSuchElementException.class)
   public void testTsNoElement() {

--- a/modules/integration/src/test/java/org/apache/fluo/integration/impl/TransactorIT.java
+++ b/modules/integration/src/test/java/org/apache/fluo/integration/impl/TransactorIT.java
@@ -24,11 +24,14 @@ import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.junit.rules.Timeout;
 
 /**
  * Tests transactor classes
  */
 public class TransactorIT extends ITBaseImpl {
+  @Rule
+  public Timeout globalTimeout = Timeout.seconds(60);
 
   public static Long id1 = Long.valueOf(2);
   public static Long id2 = Long.valueOf(3);

--- a/modules/integration/src/test/java/org/apache/fluo/integration/impl/TransactorIT.java
+++ b/modules/integration/src/test/java/org/apache/fluo/integration/impl/TransactorIT.java
@@ -31,7 +31,7 @@ import org.junit.rules.Timeout;
  */
 public class TransactorIT extends ITBaseImpl {
   @Rule
-  public Timeout globalTimeout = Timeout.seconds(60);
+  public Timeout globalTimeout = Timeout.seconds(getTestTimeout());
 
   public static Long id1 = Long.valueOf(2);
   public static Long id2 = Long.valueOf(3);

--- a/modules/integration/src/test/java/org/apache/fluo/integration/impl/WeakNotificationIT.java
+++ b/modules/integration/src/test/java/org/apache/fluo/integration/impl/WeakNotificationIT.java
@@ -21,7 +21,6 @@ import org.apache.fluo.api.client.scanner.CellScanner;
 import org.apache.fluo.api.data.Bytes;
 import org.apache.fluo.api.data.Column;
 import org.apache.fluo.api.data.RowColumnValue;
-import org.apache.fluo.api.data.Span;
 import org.apache.fluo.api.observer.Observer;
 import org.apache.fluo.api.observer.ObserverProvider;
 import org.apache.fluo.core.impl.Environment;
@@ -31,11 +30,15 @@ import org.apache.fluo.integration.ITBaseMini;
 import org.apache.fluo.integration.TestTransaction;
 import org.apache.fluo.integration.TestUtil;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 
 import static org.apache.fluo.api.observer.Observer.NotificationType.WEAK;
 
 public class WeakNotificationIT extends ITBaseMini {
+  @Rule
+  public Timeout globalTimeout = Timeout.seconds(getTestTimeout());
 
   private static final Column STAT_COUNT = new Column("stat", "count");
   private static final Column STAT_CHECK = new Column("stat", "check");
@@ -125,7 +128,7 @@ public class WeakNotificationIT extends ITBaseMini {
     env.close();
   }
 
-  @Test(timeout = 30000)
+
   public void testNOOP() throws Exception {
     // if an observer makes not updates in a transaction, it should still delete the weak
     // notification

--- a/modules/integration/src/test/java/org/apache/fluo/integration/impl/WeakNotificationOverlapIT.java
+++ b/modules/integration/src/test/java/org/apache/fluo/integration/impl/WeakNotificationOverlapIT.java
@@ -42,7 +42,7 @@ import static org.apache.fluo.api.observer.Observer.NotificationType.WEAK;
 
 public class WeakNotificationOverlapIT extends ITBaseImpl {
   @Rule
-  public Timeout globalTimeout = Timeout.seconds(60);
+  public Timeout globalTimeout = Timeout.seconds(getTestTimeout());
   private static final Column STAT_TOTAL = new Column("stat", "total");
   private static final Column STAT_PROCESSED = new Column("stat", "processed");
   private static final Column STAT_CHANGED = new Column("stat", "changed");

--- a/modules/integration/src/test/java/org/apache/fluo/integration/impl/WeakNotificationOverlapIT.java
+++ b/modules/integration/src/test/java/org/apache/fluo/integration/impl/WeakNotificationOverlapIT.java
@@ -34,12 +34,15 @@ import org.apache.fluo.integration.ITBaseImpl;
 import org.apache.fluo.integration.TestTransaction;
 import org.apache.fluo.integration.TestUtil;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 
 import static org.apache.fluo.api.observer.Observer.NotificationType.WEAK;
 
 public class WeakNotificationOverlapIT extends ITBaseImpl {
-
+  @Rule
+  public Timeout globalTimeout = Timeout.seconds(60); 
   private static final Column STAT_TOTAL = new Column("stat", "total");
   private static final Column STAT_PROCESSED = new Column("stat", "processed");
   private static final Column STAT_CHANGED = new Column("stat", "changed");

--- a/modules/integration/src/test/java/org/apache/fluo/integration/impl/WeakNotificationOverlapIT.java
+++ b/modules/integration/src/test/java/org/apache/fluo/integration/impl/WeakNotificationOverlapIT.java
@@ -42,7 +42,7 @@ import static org.apache.fluo.api.observer.Observer.NotificationType.WEAK;
 
 public class WeakNotificationOverlapIT extends ITBaseImpl {
   @Rule
-  public Timeout globalTimeout = Timeout.seconds(60); 
+  public Timeout globalTimeout = Timeout.seconds(60);
   private static final Column STAT_TOTAL = new Column("stat", "total");
   private static final Column STAT_PROCESSED = new Column("stat", "processed");
   private static final Column STAT_CHANGED = new Column("stat", "changed");

--- a/modules/integration/src/test/java/org/apache/fluo/integration/impl/WorkerIT.java
+++ b/modules/integration/src/test/java/org/apache/fluo/integration/impl/WorkerIT.java
@@ -45,7 +45,7 @@ import static org.apache.fluo.api.observer.Observer.NotificationType.STRONG;
  */
 public class WorkerIT extends ITBaseMini {
   @Rule
-  public Timeout globalTimeout = Timeout.seconds(120); 
+  public Timeout globalTimeout = Timeout.seconds(120);
   // timeout needs to be > 60secs for testMultipleFinders()
   private static final Column LAST_UPDATE = new Column("attr", "lastupdate");
   private static final Column DEGREE = new Column("attr", "degree");

--- a/modules/integration/src/test/java/org/apache/fluo/integration/impl/WorkerIT.java
+++ b/modules/integration/src/test/java/org/apache/fluo/integration/impl/WorkerIT.java
@@ -33,7 +33,9 @@ import org.apache.fluo.integration.ITBaseMini;
 import org.apache.fluo.integration.TestTransaction;
 import org.apache.fluo.mini.MiniFluoImpl;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 
 import static org.apache.fluo.api.observer.Observer.NotificationType.STRONG;
 
@@ -42,7 +44,9 @@ import static org.apache.fluo.api.observer.Observer.NotificationType.STRONG;
  * index of node degree.
  */
 public class WorkerIT extends ITBaseMini {
-
+  @Rule
+  public Timeout globalTimeout = Timeout.seconds(120); 
+  // timeout needs to be > 60secs for testMultipleFinders()
   private static final Column LAST_UPDATE = new Column("attr", "lastupdate");
   private static final Column DEGREE = new Column("attr", "degree");
 

--- a/modules/integration/src/test/java/org/apache/fluo/integration/impl/WorkerIT.java
+++ b/modules/integration/src/test/java/org/apache/fluo/integration/impl/WorkerIT.java
@@ -21,7 +21,6 @@ import org.apache.fluo.api.client.Transaction;
 import org.apache.fluo.api.client.TransactionBase;
 import org.apache.fluo.api.data.Column;
 import org.apache.fluo.api.data.RowColumn;
-import org.apache.fluo.api.data.Span;
 import org.apache.fluo.api.observer.ObserverProvider;
 import org.apache.fluo.api.observer.StringObserver;
 import org.apache.fluo.core.impl.Environment;
@@ -45,7 +44,7 @@ import static org.apache.fluo.api.observer.Observer.NotificationType.STRONG;
  */
 public class WorkerIT extends ITBaseMini {
   @Rule
-  public Timeout globalTimeout = Timeout.seconds(120);
+  public Timeout globalTimeout = Timeout.seconds(getTestTimeout() * 2);
   // timeout needs to be > 60secs for testMultipleFinders()
   private static final Column LAST_UPDATE = new Column("attr", "lastupdate");
   private static final Column DEGREE = new Column("attr", "degree");

--- a/modules/integration/src/test/java/org/apache/fluo/integration/impl/ZKSecretIT.java
+++ b/modules/integration/src/test/java/org/apache/fluo/integration/impl/ZKSecretIT.java
@@ -42,8 +42,9 @@ import static org.apache.fluo.api.observer.Observer.NotificationType.STRONG;
 public class ZKSecretIT extends ITBaseMini {
 
   public static class MyObserverProvider implements ObserverProvider {
-	@Rule
-	public Timeout globalTimeout = Timeout.seconds(60);
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(60);
+
     @Override
     public void provide(Registry or, Context ctx) {
       or.forColumn(new Column("edge", "forward"), STRONG).useObserver((tx, row, col) -> {

--- a/modules/integration/src/test/java/org/apache/fluo/integration/impl/ZKSecretIT.java
+++ b/modules/integration/src/test/java/org/apache/fluo/integration/impl/ZKSecretIT.java
@@ -27,21 +27,23 @@ import org.apache.fluo.api.client.FluoFactory;
 import org.apache.fluo.api.client.Snapshot;
 import org.apache.fluo.api.client.Transaction;
 import org.apache.fluo.api.config.FluoConfiguration;
-import org.apache.fluo.api.config.SimpleConfiguration;
 import org.apache.fluo.api.data.Column;
 import org.apache.fluo.api.observer.ObserverProvider;
 import org.apache.fluo.integration.ITBaseMini;
 import org.apache.zookeeper.KeeperException.NoAuthException;
 import org.apache.zookeeper.ZooKeeper;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 
 import static org.apache.fluo.api.observer.Observer.NotificationType.STRONG;
 
 public class ZKSecretIT extends ITBaseMini {
 
   public static class MyObserverProvider implements ObserverProvider {
-
+	@Rule
+	public Timeout globalTimeout = Timeout.seconds(60);
     @Override
     public void provide(Registry or, Context ctx) {
       or.forColumn(new Column("edge", "forward"), STRONG).useObserver((tx, row, col) -> {

--- a/modules/integration/src/test/java/org/apache/fluo/integration/impl/ZKSecretIT.java
+++ b/modules/integration/src/test/java/org/apache/fluo/integration/impl/ZKSecretIT.java
@@ -43,7 +43,7 @@ public class ZKSecretIT extends ITBaseMini {
 
   public static class MyObserverProvider implements ObserverProvider {
     @Rule
-    public Timeout globalTimeout = Timeout.seconds(60);
+    public Timeout globalTimeout = Timeout.seconds(getTestTimeout());
 
     @Override
     public void provide(Registry or, Context ctx) {

--- a/modules/integration/src/test/java/org/apache/fluo/integration/log/LogIT.java
+++ b/modules/integration/src/test/java/org/apache/fluo/integration/log/LogIT.java
@@ -55,7 +55,7 @@ import static org.apache.fluo.api.observer.Observer.NotificationType.WEAK;
 
 public class LogIT extends ITBaseMini {
   @Rule
-  public Timeout globalTimeout = Timeout.seconds(60);
+  public Timeout globalTimeout = Timeout.seconds(getTestTimeout());
   private static final Column STAT_COUNT = new Column("stat", "count");
 
   static class SimpleLoader implements Loader {

--- a/modules/integration/src/test/java/org/apache/fluo/integration/log/LogIT.java
+++ b/modules/integration/src/test/java/org/apache/fluo/integration/log/LogIT.java
@@ -36,7 +36,6 @@ import org.apache.fluo.api.data.Column;
 import org.apache.fluo.api.data.ColumnValue;
 import org.apache.fluo.api.data.RowColumn;
 import org.apache.fluo.api.data.RowColumnValue;
-import org.apache.fluo.api.data.Span;
 import org.apache.fluo.api.observer.Observer;
 import org.apache.fluo.api.observer.ObserverProvider;
 import org.apache.fluo.api.observer.StringObserver;
@@ -48,12 +47,15 @@ import org.apache.log4j.Logger;
 import org.apache.log4j.PatternLayout;
 import org.apache.log4j.WriterAppender;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 
 import static org.apache.fluo.api.observer.Observer.NotificationType.WEAK;
 
 public class LogIT extends ITBaseMini {
-
+  @Rule
+  public Timeout globalTimeout = Timeout.seconds(60);
   private static final Column STAT_COUNT = new Column("stat", "count");
 
   static class SimpleLoader implements Loader {


### PR DESCRIPTION
@keith-turner 
I went ahead and tackled this. All of the tests passed with a 60 second timeout except one, I can't remember which one, but I gave it a 120 second timeout period. There were also some unused imports that eclipse was complaining about so I fixed the warnings.