### PR TITLE
Fixes #957 Fluo scripts copy jars into fluo software dir.

### DIFF
--- a/modules/distribution/src/main/config/fluo-env.sh
+++ b/modules/distribution/src/main/config/fluo-env.sh
@@ -14,7 +14,7 @@
 ## Before fluo-env.sh is loaded, these environment variables are set and can be used in this file:
 
 # cmd - Command that is being called such as oracle, worker, etc.
-# app - Fluo application name 
+# app - Fluo application name
 # basedir - Root of Fluo installation
 # conf - Directory containing Fluo configuration
 # lib - Directory containing Fluo libraries
@@ -27,6 +27,8 @@
 export HADOOP_PREFIX="${HADOOP_PREFIX:-/path/to/hadoop}"
 ## Fluo connection properties
 export FLUO_CONN_PROPS="${FLUO_CONN_PROPS:-${conf}/fluo-conn.properties}"
+## Fluo temp directory where the fluo script will copy jars from HDFS to the local machine
+export FLUO_TMP="${FLUO_TMP:-/tmp}"
 
 ####################################################
 # Build JAVA_OPTS variable used by all Fluo commands

--- a/modules/distribution/src/main/scripts/fluo
+++ b/modules/distribution/src/main/scripts/fluo
@@ -147,7 +147,6 @@ function setup_service {
     app_lib=$(mktemp -d "$FLUO_TMP"/fluo-"$app"-XXXXXXXXX) || die "fatal: unable to allocate a temporary directory"
     # schedule removal of app_lib tmp dir when this script exits
     trap "rm -rf '""$app_lib""'" EXIT HUP INT QUIT TERM
-    mkdir -p "$app_lib"
     $JAVA org.apache.fluo.command.FluoGetJars -d "$app_lib" "$@"
     export CLASSPATH="$conf:$app_lib/*:$CLASSPATH"
   else
@@ -232,7 +231,6 @@ exec)
     app_lib=$(mktemp -d "$FLUO_TMP"/fluo-"$app"-XXXXXXXXX) || die "fatal: unable to allocate a temporary directory"
     # schedule removal of app_lib tmp dir when this script exits
     trap "rm -rf '""$app_lib""'" EXIT HUP INT QUIT TERM
-    mkdir -p "$app_lib"
     $JAVA org.apache.fluo.command.FluoGetJars -d "$app_lib" -a "$app"
     export CLASSPATH="$conf:$app_lib/*:$CLASSPATH"
     $JAVA org.apache.fluo.command.FluoExec "${@:2}"

--- a/modules/distribution/src/main/scripts/fluo
+++ b/modules/distribution/src/main/scripts/fluo
@@ -143,7 +143,10 @@ function setup_service {
     app=${BASH_REMATCH[1]}
     verify_app "$app"
     check_conn_props
-    app_lib=$lib/apps/$1
+    # create a temp dir to fetch application jars to
+    app_lib=$(mktemp -d "$FLUO_TMP"/fluo-"$app"-XXXXXXXXX) || die "fatal: unable to allocate a temporary directory"
+    # schedule removal of app_lib tmp dir when this script exits
+    trap "rm -rf '""$app_lib""'" EXIT HUP INT QUIT TERM
     mkdir -p "$app_lib"
     $JAVA org.apache.fluo.command.FluoGetJars -d "$app_lib" "$@"
     export CLASSPATH="$conf:$app_lib/*:$CLASSPATH"
@@ -225,7 +228,10 @@ exec)
     app=$2
     verify_app "$app"
     check_conn_props
-    app_lib=$lib/apps/$app
+    # create a temp dir to fetch application jars to
+    app_lib=$(mktemp -d "$FLUO_TMP"/fluo-"$app"-XXXXXXXXX) || die "fatal: unable to allocate a temporary directory"
+    # schedule removal of app_lib tmp dir when this script exits
+    trap "rm -rf '""$app_lib""'" EXIT HUP INT QUIT TERM
     mkdir -p "$app_lib"
     $JAVA org.apache.fluo.command.FluoGetJars -d "$app_lib" -a "$app"
     export CLASSPATH="$conf:$app_lib/*:$CLASSPATH"


### PR DESCRIPTION
- [x] - Setup FLUO_TMP env var which defaults to /tmp in fluo-env.sh.
- [x] - Modified the fluo script to use mktemp and FLUO_TMP everywhere FluoGetJars is run.
- [x] - Modified the fluo script to remove tmp dir after if finishes executing command.
- [x] - Ran both `mvn package` and `mvn verify` successfully.
- [x] - Tested this locally using fluo w/ Uno.