### PR TITLE
fluo-env.sh now supports FLUO_JAVA_OPTS set in environment

### DIFF
--- a/modules/distribution/src/main/config/fluo-env.sh
+++ b/modules/distribution/src/main/config/fluo-env.sh
@@ -34,9 +34,7 @@ export FLUO_CONN_PROPS="${FLUO_CONN_PROPS:-${conf}/fluo-conn.properties}"
 
 ## Fluo log4j configuration
 export FLUO_LOG4J_CONFIG="${FLUO_LOG4J_CONFIG:-${conf}/log4j.properties}"
-## Java options for Fluo command
-JAVA_OPTS="-Dlog4j.configuration=file:${FLUO_LOG4J_CONFIG}"
-##Prepending JAVA_OPTS with FLUO_JAVA_OPTS
+## Java options along with FLUO_JAVA_OPTS for Fluo command
 JAVA_OPTS=("${FLUO_JAVA_OPTS[@]}" "-Dlog4j.configuration=file:${FLUO_LOG4J_CONFIG}")
 
 

--- a/modules/distribution/src/main/config/fluo-env.sh
+++ b/modules/distribution/src/main/config/fluo-env.sh
@@ -37,10 +37,9 @@ export FLUO_LOG4J_CONFIG="${FLUO_LOG4J_CONFIG:-${conf}/log4j.properties}"
 ## Java options for Fluo command
 JAVA_OPTS="-Dlog4j.configuration=file:${FLUO_LOG4J_CONFIG}"
 ##Prepending JAVA_OPTS with FLUO_JAVA_OPTS
-for var in "${FLUO_JAVA_OPTS[@]}"
-do
-	JAVA_OPTS=("$var $JAVA_OPTS")
-done
+JAVA_OPTS=("${FLUO_JAVA_OPTS[@]}" "-Dlog4j.configuration=file:${FLUO_LOG4J_CONFIG}")
+
+
 export JAVA_OPTS
 
 ##########################

--- a/modules/distribution/src/main/config/fluo-env.sh
+++ b/modules/distribution/src/main/config/fluo-env.sh
@@ -35,9 +35,12 @@ export FLUO_CONN_PROPS="${FLUO_CONN_PROPS:-${conf}/fluo-conn.properties}"
 ## Fluo log4j configuration
 export FLUO_LOG4J_CONFIG="${FLUO_LOG4J_CONFIG:-${conf}/log4j.properties}"
 ## Java options for Fluo command
-##PREPENDING JAVA_OPTS WITH FLUO_JAVA_OPTS ENVIRONMENT VARIABLE
-JAVA_OPTS=("$FLUO_JAVA_OPTS -Dlog4j.configuration=file:${FLUO_LOG4J_CONFIG}")
-
+JAVA_OPTS="-Dlog4j.configuration=file:${FLUO_LOG4J_CONFIG}"
+##Prepending JAVA_OPTS with FLUO_JAVA_OPTS
+for var in "${FLUO_JAVA_OPTS[@]}"
+do
+	JAVA_OPTS=("$var $JAVA_OPTS")
+done
 export JAVA_OPTS
 
 ##########################

--- a/modules/distribution/src/main/config/fluo-env.sh
+++ b/modules/distribution/src/main/config/fluo-env.sh
@@ -35,7 +35,9 @@ export FLUO_CONN_PROPS="${FLUO_CONN_PROPS:-${conf}/fluo-conn.properties}"
 ## Fluo log4j configuration
 export FLUO_LOG4J_CONFIG="${FLUO_LOG4J_CONFIG:-${conf}/log4j.properties}"
 ## Java options for Fluo command
-JAVA_OPTS=("-Dlog4j.configuration=file:${FLUO_LOG4J_CONFIG}")
+##PREPENDING JAVA_OPTS WITH FLUO_JAVA_OPTS ENVIRONMENT VARIABLE
+JAVA_OPTS=("$FLUO_JAVA_OPTS -Dlog4j.configuration=file:${FLUO_LOG4J_CONFIG}")
+
 export JAVA_OPTS
 
 ##########################


### PR DESCRIPTION
Appended FLUO_JAVA_OPTS to JAVA_OPTS in fluo-env.sh  . This allows to set FLUO_JAVA_OPTS to set from command line . #954 
