### PR TITLE
Revert back to formatter-maven-plugin 2.7.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -136,7 +136,7 @@
         <plugin>
           <groupId>net.revelc.code.formatter</groupId>
           <artifactId>formatter-maven-plugin</artifactId>
-          <version>2.7.1</version>
+          <version>2.7.0</version>
           <configuration>
             <lineEnding>LF</lineEnding>
             <overrideConfigCompilerVersion>true</overrideConfigCompilerVersion>


### PR DESCRIPTION
Version 2.7.1 had an issue in revelc/formatter-maven-plugin#260
This reverts back to version 2.7.0, which seems to work fine with Fluo