### PR TITLE
Make libthrift dependency "provided"

### DIFF
--- a/modules/core/pom.xml
+++ b/modules/core/pom.xml
@@ -74,10 +74,6 @@
       <artifactId>hadoop-client</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.thrift</groupId>
-      <artifactId>libthrift</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.apache.zookeeper</groupId>
       <artifactId>zookeeper</artifactId>
     </dependency>
@@ -88,6 +84,19 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.thrift</groupId>
+      <artifactId>libthrift</artifactId>
+      <!--
+         Ensure that this does not get included in the set of transitive
+         dependencies coming from fluo-core; the specific version of
+         libthrift required for a particular Fluo application at runtime must
+         also be compatible with the libthrift version required by the
+         Accumulo client code, and should be brought in transitively from the
+         Accumulo dependencies.
+      -->
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
Ensure that libthrift does not get included in the set of transitive
dependencies coming from fluo-core, so that it comes from Accumulo instead.

The specific version of libthrift required for a particular Fluo application at
runtime must be compatible with both the libthrift version required by the Fluo
Oracle service and also the Accumulo client code. Since Fluo applications are
both an Accumulo client and a Fluo Oracle client, and it does not do class path
isolation between the different client dependencies for each, the version of
libthrift used must be compatible with both.

Luckily, the meager use of of thrift for Fluo's Oracle means that its client is
compatible with many versions of thrift, so Fluo applications should use the
version which is most compatible with Accumulo. Marking this dependency as
"provided" in fluo-core will make Fluo applications depending on fluo-core
transitively use the version coming from their Accumulo dependency instead of
their fluo-core dependency.