### PR TITLE
Issue #1000 part A

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
   </issueManagement>
   <properties>
     <accumulo.version>1.7.3</accumulo.version>
-    <curator.version>2.7.1</curator.version>
+    <curator.version>2.12.0</curator.version>
     <dropwizard.version>0.8.1</dropwizard.version>
     <findbugs.maxRank>11</findbugs.maxRank>
     <hadoop.version>2.6.3</hadoop.version>


### PR DESCRIPTION
Upgrade the Curator Framework from version 2.7.1 to 2.12.0

This upgrades Curator to a more recent version. This does not fix the errors during mvn verify but it prepares the way. Consult the release documentation for a comprehensive list of bugs that have been fixed between the multiple releases.

Although this does not cure #1000 this should be done anyways IMO.