### PR TITLE
FLUO-1038 Use try with resources for streams in FluoAdminImpl

### DIFF
--- a/modules/core/src/main/java/org/apache/fluo/core/client/FluoAdminImpl.java
+++ b/modules/core/src/main/java/org/apache/fluo/core/client/FluoAdminImpl.java
@@ -329,11 +329,11 @@ public class FluoAdminImpl implements FluoAdmin {
       }
     }
 
-    try {
+    try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
       CuratorFramework curator = getAppCurator();
       ObserverUtil.initialize(curator, config);
 
-      ByteArrayOutputStream baos = new ByteArrayOutputStream();
+
       sharedProps.store(baos, "Shared java props");
 
       CuratorUtil.putData(curator, ZookeeperPath.CONFIG_SHARED, baos.toByteArray(),
@@ -451,13 +451,14 @@ public class FluoAdminImpl implements FluoAdmin {
     try (CuratorFramework curator = CuratorUtil.newAppCurator(config)) {
       curator.start();
 
-      ByteArrayInputStream bais =
-          new ByteArrayInputStream(curator.getData().forPath(ZookeeperPath.CONFIG_SHARED));
-      Properties sharedProps = new Properties();
-      sharedProps.load(bais);
+      try (ByteArrayInputStream bais =
+          new ByteArrayInputStream(curator.getData().forPath(ZookeeperPath.CONFIG_SHARED))) {
 
-      for (String prop : sharedProps.stringPropertyNames()) {
-        zooConfig.setProperty(prop, sharedProps.getProperty(prop));
+        Properties sharedProps = new Properties();
+        sharedProps.load(bais);
+        for (String prop : sharedProps.stringPropertyNames()) {
+          zooConfig.setProperty(prop, sharedProps.getProperty(prop));
+        }
       }
     } catch (Exception e) {
       throw new IllegalStateException(e);


### PR DESCRIPTION
For #1038 use try with resources for all streams, even byte array based streams so we can: 
a) be consistent with streams and use of try with resources
b) if the stream is ever changed to one that _needs_ to be closed it is already wrapped