### PR TITLE
Upgrade Hadoop from version 2.6.3 to 3.0.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
     <curator.version>2.12.0</curator.version>
     <dropwizard.version>0.8.1</dropwizard.version>
     <findbugs.maxRank>11</findbugs.maxRank>
-    <hadoop.version>2.6.3</hadoop.version>
+    <hadoop.version>3.0.2</hadoop.version>
     <logback.version>1.1.3</logback.version>
     <releaseProfiles>fluo-release</releaseProfiles>
     <slf4j.version>1.7.12</slf4j.version>


### PR DESCRIPTION
This patch updates the Hadoop version from 2.6.3 to 3.0.2 to match the version Accumulo is currently using and reap the bug fix benefits.