### PR TITLE
Fix javadoc memory issues with Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,11 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+
+# requiring sudo forces Travis to build in an environment with more RAM
+sudo: required
 language: java
-# speed up builds; don't use with default install step
+# speed up builds; don't use cache with default install step
 cache:
   directories:
     - $HOME/.m2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,19 @@
-# Licensed to the Apache Software Foundation (ASF) under one or more contributor license
-# agreements. See the NOTICE file distributed with this work for additional information regarding
-# copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance with the License. You may obtain a
-# copy of the License at
+#  Licensed to the Apache Software Foundation (ASF) under one or more
+#  contributor license agreements.  See the NOTICE file distributed with
+#  this work for additional information regarding copyright ownership.
+#  The ASF licenses this file to You under the Apache License, Version 2.0
+#  (the "License"); you may not use this file except in compliance with
+#  the License.  You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#      http://www.apache.org/licenses/LICENSE-2.0
 #
-# Unless required by applicable law or agreed to in writing, software distributed under the License
-# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
-# or implied. See the License for the specific language governing permissions and limitations under
-# the License.
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
 language: java
-notifications:
-  irc:
-    channels:
-      - "chat.freenode.net#fluo"
-    use_notice: true
-    on_success: change
-    on_failure: always
-    skip_join: true
+# speed up builds; don't use with default install step
 cache:
   directories:
     - $HOME/.m2
@@ -28,7 +23,7 @@ jdk:
 before_script:
   - unset _JAVA_OPTIONS
 env:
-  - ADDITIONAL_MAVEN_OPTS=
-  - ADDITIONAL_MAVEN_OPTS=-Daccumulo.version=1.9.1
+  - BUILD_ARGS="clean verify javadoc:jar"
+  - BUILD_ARGS="clean verify javadoc:jar -Daccumulo.version=1.9.2"
 script:
-  - mvn clean verify javadoc:jar $ADDITIONAL_MAVEN_OPTS
+  - mvn $BUILD_ARGS

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,8 @@ cache:
 install: echo NOOP Skipping pre-fetch of Maven dependencies
 jdk:
   - openjdk8
+before_script:
+  - unset _JAVA_OPTIONS
 env:
   - ADDITIONAL_MAVEN_OPTS=
   - ADDITIONAL_MAVEN_OPTS=-Daccumulo.version=1.9.1


### PR DESCRIPTION
Unset _JAVA_OPTIONS environment, which interferes with the default
settings of certain Maven plugins, and causes the build to run out of
memory and be killed by the Travis host.