### PR TITLE
Fluo source cleanup/simplification

### DIFF
--- a/modules/accumulo/src/main/java/org/apache/fluo/accumulo/iterators/SnapshotIterator.java
+++ b/modules/accumulo/src/main/java/org/apache/fluo/accumulo/iterators/SnapshotIterator.java
@@ -248,7 +248,7 @@ public class SnapshotIterator implements SortedKeyValueIterator<Key, Value> {
       newRange = range;
     }
 
-    if (columnFamilies.size() == 0 && inclusive == false) {
+    if (columnFamilies.isEmpty() && inclusive == false) {
       cols = NOTIFY_CF_SET;
       inc = false;
     } else {

--- a/modules/accumulo/src/main/java/org/apache/fluo/accumulo/util/NotificationUtil.java
+++ b/modules/accumulo/src/main/java/org/apache/fluo/accumulo/util/NotificationUtil.java
@@ -60,7 +60,6 @@ public class NotificationUtil {
 
   public static Column decodeCol(byte[] cq) {
     List<Bytes> ca = ByteArrayUtil.split(cq);
-    Column col = new Column(ca.get(0), ca.get(1));
-    return col;
+    return new Column(ca.get(0), ca.get(1));
   }
 }

--- a/modules/accumulo/src/test/java/org/apache/fluo/accumulo/iterators/ColumnBufferTest.java
+++ b/modules/accumulo/src/test/java/org/apache/fluo/accumulo/iterators/ColumnBufferTest.java
@@ -15,8 +15,6 @@
 
 package org.apache.fluo.accumulo.iterators;
 
-import java.lang.IllegalArgumentException;
-
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Value;
 import org.junit.Assert;

--- a/modules/api/src/main/java/org/apache/fluo/api/config/FluoConfiguration.java
+++ b/modules/api/src/main/java/org/apache/fluo/api/config/FluoConfiguration.java
@@ -319,7 +319,7 @@ public class FluoConfiguration extends SimpleConfiguration {
     if (name == null) {
       throw new IllegalArgumentException("Application name cannot be null");
     }
-    if (name.length() == 0) {
+    if (name.isEmpty()) {
       throw new IllegalArgumentException("Application name length must be > 0");
     }
     String reason = null;

--- a/modules/api/src/main/java/org/apache/fluo/api/data/Bytes.java
+++ b/modules/api/src/main/java/org/apache/fluo/api/data/Bytes.java
@@ -409,7 +409,7 @@ public final class Bytes implements Comparable<Bytes>, Serializable {
    */
   public static final Bytes of(String s) {
     Objects.requireNonNull(s);
-    if (s.length() == 0) {
+    if (s.isEmpty()) {
       return EMPTY;
     }
     byte[] data = s.getBytes(StandardCharsets.UTF_8);
@@ -422,7 +422,7 @@ public final class Bytes implements Comparable<Bytes>, Serializable {
   public static final Bytes of(String s, Charset c) {
     Objects.requireNonNull(s);
     Objects.requireNonNull(c);
-    if (s.length() == 0) {
+    if (s.isEmpty()) {
       return EMPTY;
     }
     byte[] data = s.getBytes(c);

--- a/modules/api/src/main/java/org/apache/fluo/api/observer/StringObserver.java
+++ b/modules/api/src/main/java/org/apache/fluo/api/observer/StringObserver.java
@@ -30,5 +30,5 @@ public interface StringObserver extends Observer {
     process(tx, row.toString(), col);
   }
 
-  abstract void process(TransactionBase tx, String row, Column col) throws Exception;
+  void process(TransactionBase tx, String row, Column col) throws Exception;
 }

--- a/modules/api/src/test/java/org/apache/fluo/api/data/BytesBuilderTest.java
+++ b/modules/api/src/test/java/org/apache/fluo/api/data/BytesBuilderTest.java
@@ -20,7 +20,6 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 
-import org.apache.fluo.api.data.Bytes;
 import org.apache.fluo.api.data.Bytes.BytesBuilder;
 import org.junit.Assert;
 import org.junit.Test;

--- a/modules/api/src/test/java/org/apache/fluo/api/data/BytesTest.java
+++ b/modules/api/src/test/java/org/apache/fluo/api/data/BytesTest.java
@@ -17,7 +17,6 @@ package org.apache.fluo.api.data;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.lang.IllegalArgumentException;
 import java.nio.ByteBuffer;
 import java.nio.ReadOnlyBufferException;
 import java.nio.charset.StandardCharsets;

--- a/modules/api/src/test/java/org/apache/fluo/api/data/ColumnTest.java
+++ b/modules/api/src/test/java/org/apache/fluo/api/data/ColumnTest.java
@@ -15,8 +15,6 @@
 
 package org.apache.fluo.api.data;
 
-import org.apache.fluo.api.data.Bytes;
-import org.apache.fluo.api.data.Column;
 import org.junit.Assert;
 import org.junit.Test;
 

--- a/modules/api/src/test/java/org/apache/fluo/api/data/ColumnValueTest.java
+++ b/modules/api/src/test/java/org/apache/fluo/api/data/ColumnValueTest.java
@@ -62,8 +62,8 @@ public class ColumnValueTest {
     ColumnValue cv3 = new ColumnValue(c1, "v2");
     ColumnValue cv4 = new ColumnValue(c1, "v1");
 
-    Assert.assertTrue(cv1.compareTo(cv1) == 0);
-    Assert.assertTrue(cv1.compareTo(cv4) == 0);
+    Assert.assertEquals(0, cv1.compareTo(cv1));
+    Assert.assertEquals(0, cv1.compareTo(cv4));
     Assert.assertTrue(cv1.compareTo(cv2) < 0);
     Assert.assertTrue(cv2.compareTo(cv1) > 0);
     Assert.assertTrue(cv1.compareTo(cv3) < 0);

--- a/modules/api/src/test/java/org/apache/fluo/api/data/RowColumnTest.java
+++ b/modules/api/src/test/java/org/apache/fluo/api/data/RowColumnTest.java
@@ -15,9 +15,6 @@
 
 package org.apache.fluo.api.data;
 
-import org.apache.fluo.api.data.Bytes;
-import org.apache.fluo.api.data.Column;
-import org.apache.fluo.api.data.RowColumn;
 import org.junit.Assert;
 import org.junit.Test;
 

--- a/modules/api/src/test/java/org/apache/fluo/api/data/RowColumnValueTest.java
+++ b/modules/api/src/test/java/org/apache/fluo/api/data/RowColumnValueTest.java
@@ -19,9 +19,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import org.apache.fluo.api.data.Bytes;
-import org.apache.fluo.api.data.Column;
-import org.apache.fluo.api.data.RowColumnValue;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -60,8 +57,8 @@ public class RowColumnValueTest {
 
   @Test
   public void testCompare() {
-    Assert.assertTrue(rcv1.compareTo(rcv1) == 0);
-    Assert.assertTrue(rcv1.compareTo(rcv2) == 0);
+    Assert.assertEquals(0, rcv1.compareTo(rcv1));
+    Assert.assertEquals(0, rcv1.compareTo(rcv2));
     Assert.assertTrue(rcv1.compareTo(rcv3) < 0);
     Assert.assertTrue(rcv3.compareTo(rcv1) > 0);
     Assert.assertTrue(rcv1.compareTo(rcv3) < 0);

--- a/modules/api/src/test/java/org/apache/fluo/api/data/SpanTest.java
+++ b/modules/api/src/test/java/org/apache/fluo/api/data/SpanTest.java
@@ -15,10 +15,6 @@
 
 package org.apache.fluo.api.data;
 
-import org.apache.fluo.api.data.Bytes;
-import org.apache.fluo.api.data.Column;
-import org.apache.fluo.api.data.RowColumn;
-import org.apache.fluo.api.data.Span;
 import org.junit.Assert;
 import org.junit.Test;
 

--- a/modules/api/src/test/java/org/apache/fluo/api/exceptions/FluoExceptionTest.java
+++ b/modules/api/src/test/java/org/apache/fluo/api/exceptions/FluoExceptionTest.java
@@ -23,7 +23,7 @@ public class FluoExceptionTest {
   @Test
   public void testFluoExceptionConstructors() {
     FluoException e = new FluoException();
-    Assert.assertEquals(null, e.getMessage());
+    Assert.assertNull(e.getMessage());
 
     e = new FluoException("msg1");
     Assert.assertEquals("msg1", e.getMessage());
@@ -44,7 +44,7 @@ public class FluoExceptionTest {
   public void testCatchFluo() {
     try {
       throwFluoException();
-      Assert.assertFalse(true);
+      Assert.fail();
     } catch (FluoException e) {
     }
   }
@@ -58,13 +58,13 @@ public class FluoExceptionTest {
   public void testCatchCommit() {
     try {
       throwCommitException();
-      Assert.assertFalse(true);
+      Assert.fail();
     } catch (FluoException e) {
     }
 
     try {
       throwCommitException();
-      Assert.assertFalse(true);
+      Assert.fail();
     } catch (CommitException e) {
     }
   }
@@ -78,13 +78,13 @@ public class FluoExceptionTest {
   public void testCatchAlreadySet() {
     try {
       throwAlreadySetException();
-      Assert.assertFalse(true);
+      Assert.fail();
     } catch (FluoException e) {
     }
 
     try {
       throwAlreadySetException();
-      Assert.assertFalse(true);
+      Assert.fail();
     } catch (AlreadySetException e) {
     }
   }

--- a/modules/command/src/main/java/org/apache/fluo/command/FluoRemove.java
+++ b/modules/command/src/main/java/org/apache/fluo/command/FluoRemove.java
@@ -15,7 +15,6 @@
 
 package org.apache.fluo.command;
 
-import org.apache.fluo.api.client.FluoAdmin;
 import org.apache.fluo.api.config.FluoConfiguration;
 import org.apache.fluo.api.exceptions.FluoException;
 import org.apache.fluo.core.client.FluoAdminImpl;

--- a/modules/core/src/main/java/org/apache/fluo/core/async/AsyncConditionalWriter.java
+++ b/modules/core/src/main/java/org/apache/fluo/core/async/AsyncConditionalWriter.java
@@ -53,7 +53,7 @@ public class AsyncConditionalWriter {
   }
 
   public CompletableFuture<Iterator<Result>> apply(Collection<ConditionalMutation> input) {
-    if (input.size() == 0) {
+    if (input.isEmpty()) {
       return CompletableFuture.completedFuture(Collections.<Result>emptyList().iterator());
     }
 

--- a/modules/core/src/main/java/org/apache/fluo/core/impl/LockResolver.java
+++ b/modules/core/src/main/java/org/apache/fluo/core/impl/LockResolver.java
@@ -202,7 +202,7 @@ public class LockResolver {
       }
     }
 
-    if (mutations.size() > 0) {
+    if (!mutations.isEmpty()) {
       env.getSharedResources().getBatchWriter().writeMutations(new ArrayList<>(mutations.values()));
     }
 

--- a/modules/core/src/main/java/org/apache/fluo/core/impl/ParallelSnapshotScanner.java
+++ b/modules/core/src/main/java/org/apache/fluo/core/impl/ParallelSnapshotScanner.java
@@ -104,7 +104,7 @@ public class ParallelSnapshotScanner {
     scanner.clearColumns();
     scanner.clearScanIterators();
 
-    if (rangesToScan.size() > 0) {
+    if (!rangesToScan.isEmpty()) {
       scanner.setRanges(rangesToScan);
       SnapshotScanner.setupScanner(scanner, Collections.<Column>emptySet(), startTs, true);
     } else if (rows != null) {
@@ -136,7 +136,7 @@ public class ParallelSnapshotScanner {
 
       scan(ret, locks);
 
-      if (locks.size() > 0) {
+      if (!locks.isEmpty()) {
 
         boolean resolvedAll = LockResolver.resolveLocks(env, startTs, stats, locks, startTime);
 

--- a/modules/core/src/main/java/org/apache/fluo/core/impl/SharedBatchWriter.java
+++ b/modules/core/src/main/java/org/apache/fluo/core/impl/SharedBatchWriter.java
@@ -83,9 +83,9 @@ public class SharedBatchWriter {
       boolean keepRunning = true;
       ArrayList<MutationBatch> batches = new ArrayList<>();
 
-      while (keepRunning || batches.size() > 0) {
+      while (keepRunning || !batches.isEmpty()) {
         try {
-          if (batches.size() == 0) {
+          if (batches.isEmpty()) {
             batches.add(mutQueue.take());
           }
           mutQueue.drainTo(batches);
@@ -154,7 +154,7 @@ public class SharedBatchWriter {
 
   void writeMutations(Collection<Mutation> ml) {
 
-    if (ml.size() == 0) {
+    if (ml.isEmpty()) {
       return;
     }
 
@@ -168,7 +168,7 @@ public class SharedBatchWriter {
   }
 
   CompletableFuture<Void> writeMutationsAsyncFuture(Collection<Mutation> ml) {
-    if (ml.size() == 0) {
+    if (ml.isEmpty()) {
       return CompletableFuture.completedFuture(NULLS.get());
     }
 

--- a/modules/core/src/main/java/org/apache/fluo/core/impl/TimestampTracker.java
+++ b/modules/core/src/main/java/org/apache/fluo/core/impl/TimestampTracker.java
@@ -75,7 +75,7 @@ public class TimestampTracker implements AutoCloseable {
 
             if (allocationsInProgress > 0) {
               sawZeroCount = 0;
-              if (timestamps.size() > 0) {
+              if (!timestamps.isEmpty()) {
                 if (updatingZk) {
                   throw new IllegalStateException("expected updatingZk to be false");
                 }
@@ -210,7 +210,7 @@ public class TimestampTracker implements AutoCloseable {
     Preconditions.checkState(!updatingZk, "unexpected concurrent ZK update");
 
     if (allocationsInProgress > 0) {
-      if (timestamps.size() > 0) {
+      if (!timestamps.isEmpty()) {
         updateZkNode(timestamps.first());
       }
     } else if (allocationsInProgress == 0) {
@@ -237,7 +237,7 @@ public class TimestampTracker implements AutoCloseable {
 
   @VisibleForTesting
   public String getNodePath() {
-    return ZookeeperPath.TRANSACTOR_TIMESTAMPS + "/" + tid.toString();
+    return ZookeeperPath.TRANSACTOR_TIMESTAMPS + "/" + tid;
   }
 
   @Override

--- a/modules/core/src/main/java/org/apache/fluo/core/impl/TransactionImpl.java
+++ b/modules/core/src/main/java/org/apache/fluo/core/impl/TransactionImpl.java
@@ -195,7 +195,7 @@ public class TransactionImpl extends AbstractTransactionBase implements AsyncTra
   public Map<Bytes, Map<Column, Bytes>> get(Collection<Bytes> rows, Set<Column> columns) {
     checkIfOpen();
 
-    if (rows.size() == 0 || columns.size() == 0) {
+    if (rows.isEmpty() || columns.isEmpty()) {
       return Collections.emptyMap();
     }
 
@@ -217,7 +217,7 @@ public class TransactionImpl extends AbstractTransactionBase implements AsyncTra
   public Map<RowColumn, Bytes> get(Collection<RowColumn> rowColumns) {
     checkIfOpen();
 
-    if (rowColumns.size() == 0) {
+    if (rowColumns.isEmpty()) {
       return Collections.emptyMap();
     }
 
@@ -469,7 +469,7 @@ public class TransactionImpl extends AbstractTransactionBase implements AsyncTra
 
     public String getShortCollisionMessage() {
       StringBuilder sb = new StringBuilder();
-      if (getRejected().size() > 0) {
+      if (!getRejected().isEmpty()) {
         int numCollisions = 0;
         for (Set<Column> cols : getRejected().values()) {
           numCollisions += cols.size();
@@ -567,7 +567,7 @@ public class TransactionImpl extends AbstractTransactionBase implements AsyncTra
       } else {
         HashSet<Column> colsToRead = new HashSet<>(entry.getValue());
         colsToRead.removeAll(rowColsRead);
-        if (colsToRead.size() > 0) {
+        if (!colsToRead.isEmpty()) {
           columnsToRead.put(entry.getKey(), colsToRead);
         }
       }
@@ -581,7 +581,7 @@ public class TransactionImpl extends AbstractTransactionBase implements AsyncTra
   private void checkForOrphanedReadLocks(CommitData cd, Map<Bytes, Set<Column>> locksResolved)
       throws Exception {
 
-    if (readLocksSeen.size() == 0) {
+    if (readLocksSeen.isEmpty()) {
       return;
     }
 
@@ -617,7 +617,7 @@ public class TransactionImpl extends AbstractTransactionBase implements AsyncTra
       }
     }
 
-    if (rowColsToCheck.size() > 0) {
+    if (!rowColsToCheck.isEmpty()) {
 
       long waitTime = SnapshotScanner.INITIAL_WAIT_TIME;
 
@@ -1050,7 +1050,7 @@ public class TransactionImpl extends AbstractTransactionBase implements AsyncTra
         }
       }
 
-      return cd.getRejected().size() == 0;
+      return cd.getRejected().isEmpty();
     }
 
     @Override
@@ -1426,7 +1426,7 @@ public class TransactionImpl extends AbstractTransactionBase implements AsyncTra
 
   private CommitData setUpBeginCommitAsync(CommitData cd, AsyncCommitObserver commitCallback,
       RowColumn primary) {
-    if (updates.size() == 0) {
+    if (updates.isEmpty()) {
       // TODO do async
       deleteWeakRow();
       commitCallback.committed();
@@ -1474,7 +1474,7 @@ public class TransactionImpl extends AbstractTransactionBase implements AsyncTra
     Map<Column, Bytes> colSet = updates.get(cd.prow);
     cd.pcol = primCol;
     cd.pval = colSet.remove(primCol);
-    if (colSet.size() == 0) {
+    if (colSet.isEmpty()) {
       updates.remove(cd.prow);
     }
 

--- a/modules/core/src/main/java/org/apache/fluo/core/impl/TxStats.java
+++ b/modules/core/src/main/java/org/apache/fluo/core/impl/TxStats.java
@@ -125,7 +125,7 @@ public class TxStats {
 
   public void setRejected(Map<Bytes, Set<Column>> rejected) {
     Objects.requireNonNull(rejected);
-    Preconditions.checkState(this.rejected.size() == 0);
+    Preconditions.checkState(this.rejected.isEmpty());
     this.rejected = rejected;
     this.collisions = -1;
   }

--- a/modules/core/src/main/java/org/apache/fluo/core/impl/scanner/CellScannerImpl.java
+++ b/modules/core/src/main/java/org/apache/fluo/core/impl/scanner/CellScannerImpl.java
@@ -60,7 +60,7 @@ public class CellScannerImpl implements CellScanner {
 
   CellScannerImpl(Iterable<Entry<Key, Value>> snapshot, Collection<Column> columns) {
     this.snapshot = snapshot;
-    if (columns.size() == 0) {
+    if (columns.isEmpty()) {
       columnConverter = ColumnUtil::convert;
     } else {
       columnConverter = new CachedColumnConverter(columns);

--- a/modules/core/src/main/java/org/apache/fluo/core/impl/scanner/RowScannerImpl.java
+++ b/modules/core/src/main/java/org/apache/fluo/core/impl/scanner/RowScannerImpl.java
@@ -37,7 +37,7 @@ public class RowScannerImpl implements RowScanner {
 
   RowScannerImpl(Iterable<Entry<Key, Value>> snapshot, Collection<Column> columns) {
     this.snapshot = snapshot;
-    if (columns.size() == 0) {
+    if (columns.isEmpty()) {
       columnConverter = ColumnUtil::convert;
     } else {
       columnConverter = new CachedColumnConverter(columns);

--- a/modules/core/src/main/java/org/apache/fluo/core/observer/v1/ObserverStoreV1.java
+++ b/modules/core/src/main/java/org/apache/fluo/core/observer/v1/ObserverStoreV1.java
@@ -159,8 +159,7 @@ public class ObserverStoreV1 implements ObserverStore {
       serializeObservers(dos, weakObservers);
     }
 
-    byte[] serializedObservers = baos.toByteArray();
-    return serializedObservers;
+    return baos.toByteArray();
   }
 
   private static Map<Column, org.apache.fluo.api.config.ObserverSpecification> readObservers(

--- a/modules/core/src/main/java/org/apache/fluo/core/observer/v1/ObserversV1.java
+++ b/modules/core/src/main/java/org/apache/fluo/core/observer/v1/ObserversV1.java
@@ -80,7 +80,7 @@ class ObserversV1 implements Observers {
     observerList = getObserverList(col);
 
     synchronized (observerList) {
-      if (observerList.size() > 0) {
+      if (!observerList.isEmpty()) {
         return observerList.remove(observerList.size() - 1);
       }
     }

--- a/modules/core/src/main/java/org/apache/fluo/core/observer/v2/ObserversV2.java
+++ b/modules/core/src/main/java/org/apache/fluo/core/observer/v2/ObserversV2.java
@@ -51,7 +51,7 @@ class ObserversV2 implements Observers {
     // the following check ensures observers are provided for all previously configured columns
     SetView<Column> diff =
         Sets.difference(observers.keySet(), Sets.union(strongColumns, weakColumns));
-    if (diff.size() > 0) {
+    if (!diff.isEmpty()) {
       throw new FluoException("ObserverProvider " + jco.getObserverProviderClass()
           + " did not provide observers for columns " + diff);
     }

--- a/modules/core/src/main/java/org/apache/fluo/core/util/FluoExecutors.java
+++ b/modules/core/src/main/java/org/apache/fluo/core/util/FluoExecutors.java
@@ -30,8 +30,8 @@ public class FluoExecutors {
 
   public static ThreadPoolExecutor newFixedThreadPool(int numThreads, BlockingQueue<Runnable> queue,
       String name) {
-    ThreadPoolExecutor tpe = new ThreadPoolExecutor(numThreads, numThreads, 0L,
-        TimeUnit.MILLISECONDS, queue, new FluoThreadFactory(name)) {
+    return new ThreadPoolExecutor(numThreads, numThreads, 0L, TimeUnit.MILLISECONDS, queue,
+        new FluoThreadFactory(name)) {
       @Override
       protected void afterExecute(Runnable r, Throwable t) {
         if (t != null) {
@@ -47,6 +47,5 @@ public class FluoExecutors {
         }
       }
     };
-    return tpe;
   }
 }

--- a/modules/core/src/main/java/org/apache/fluo/core/util/NotificationScanner.java
+++ b/modules/core/src/main/java/org/apache/fluo/core/util/NotificationScanner.java
@@ -40,7 +40,7 @@ public class NotificationScanner implements CellScanner {
   private Predicate<RowColumnValue> filter;
 
   private static Predicate<RowColumnValue> createColumnFilter(Collection<Column> allColumns) {
-    if (allColumns.size() == 0) {
+    if (allColumns.isEmpty()) {
       return rcv -> true;
     } else {
       Set<Bytes> families = allColumns.stream().filter(col -> !col.isQualifierSet())
@@ -48,9 +48,9 @@ public class NotificationScanner implements CellScanner {
       Set<Column> columns =
           allColumns.stream().filter(col -> col.isQualifierSet()).collect(toSet());
 
-      if (families.size() == 0) {
+      if (families.isEmpty()) {
         return rcv -> columns.contains(rcv.getColumn());
-      } else if (columns.size() == 0) {
+      } else if (columns.isEmpty()) {
         return rcv -> families.contains(rcv.getColumn().getFamily());
       } else {
         return rcv -> families.contains(rcv.getColumn().getFamily())

--- a/modules/core/src/main/java/org/apache/fluo/core/worker/NotificationProcessor.java
+++ b/modules/core/src/main/java/org/apache/fluo/core/worker/NotificationProcessor.java
@@ -149,7 +149,7 @@ public class NotificationProcessor implements AutoCloseable {
 
     public synchronized void finishAddingNotifications(long sessionId) {
       this.memoryPredicates.remove(sessionId);
-      if (memoryPredicates.size() == 0) {
+      if (memoryPredicates.isEmpty()) {
         recentlyDeleted.clear();
         memoryPredicate = rc -> false;
       } else {

--- a/modules/core/src/main/java/org/apache/fluo/core/worker/finder/hash/TableRange.java
+++ b/modules/core/src/main/java/org/apache/fluo/core/worker/finder/hash/TableRange.java
@@ -85,8 +85,8 @@ public class TableRange implements Comparable<TableRange> {
       tablets.add(new TableRange(i == 0 ? null : sortedRows.get(i - 1), sortedRows.get(i)));
     }
 
-    tablets.add(new TableRange(
-        sortedRows.size() == 0 ? null : sortedRows.get(sortedRows.size() - 1), null));
+    tablets.add(
+        new TableRange(sortedRows.isEmpty() ? null : sortedRows.get(sortedRows.size() - 1), null));
     return tablets;
 
   }

--- a/modules/core/src/test/java/org/apache/fluo/core/util/SpanUtilTest.java
+++ b/modules/core/src/test/java/org/apache/fluo/core/util/SpanUtilTest.java
@@ -28,7 +28,7 @@ public class SpanUtilTest {
 
   @Test
   public void testToKey() {
-    Assert.assertEquals(null, SpanUtil.toKey(null));
+    Assert.assertNull(SpanUtil.toKey(null));
     Assert.assertEquals(new Key("row"), SpanUtil.toKey(new RowColumn("row")));
     Assert.assertEquals(new Key("row", "cf"),
         SpanUtil.toKey(new RowColumn("row", new Column("cf"))));

--- a/modules/core/src/test/java/org/apache/fluo/core/worker/finder/hash/SerializedSplitsTest.java
+++ b/modules/core/src/test/java/org/apache/fluo/core/worker/finder/hash/SerializedSplitsTest.java
@@ -46,7 +46,7 @@ public class SerializedSplitsTest {
     int expectedDiff = Integer.parseInt(splits2.get(1).toString(), 16)
         - Integer.parseInt(splits2.get(0).toString(), 16);
     Assert.assertTrue(expectedDiff > 13);
-    Assert.assertTrue(expectedDiff % 13 == 0);
+    Assert.assertEquals(0, expectedDiff % 13);
     // check that splits are evenly spaced
     for (int i = 1; i < splits2.size(); i++) {
       int sp1 = Integer.parseInt(splits2.get(i - 1).toString(), 16);

--- a/modules/core/src/test/java/org/apache/fluo/core/worker/finder/hash/TableRangeTest.java
+++ b/modules/core/src/test/java/org/apache/fluo/core/worker/finder/hash/TableRangeTest.java
@@ -101,15 +101,15 @@ public class TableRangeTest {
     Assert.assertTrue(tr1.compareTo(tr3) < 0);
     Assert.assertTrue(tr3.compareTo(tr1) > 0);
 
-    Assert.assertTrue(tr1.compareTo(tr1) == 0);
-    Assert.assertTrue(tr2.compareTo(tr2) == 0);
-    Assert.assertTrue(tr3.compareTo(tr3) == 0);
+    Assert.assertEquals(0, tr1.compareTo(tr1));
+    Assert.assertEquals(0, tr2.compareTo(tr2));
+    Assert.assertEquals(0, tr3.compareTo(tr3));
 
-    Assert.assertTrue(tr1.compareTo(new TableRange(null, sp1)) == 0);
-    Assert.assertTrue(tr2.compareTo(new TableRange(sp1, sp2)) == 0);
-    Assert.assertTrue(tr3.compareTo(new TableRange(sp2, null)) == 0);
+    Assert.assertEquals(0, tr1.compareTo(new TableRange(null, sp1)));
+    Assert.assertEquals(0, tr2.compareTo(new TableRange(sp1, sp2)));
+    Assert.assertEquals(0, tr3.compareTo(new TableRange(sp2, null)));
 
-    Assert.assertTrue(new TableRange(null, null).compareTo(new TableRange(null, null)) == 0);
+    Assert.assertEquals(0, new TableRange(null, null).compareTo(new TableRange(null, null)));
   }
 
   @Test

--- a/modules/integration-tests/src/main/java/org/apache/fluo/integration/impl/FailureIT.java
+++ b/modules/integration-tests/src/main/java/org/apache/fluo/integration/impl/FailureIT.java
@@ -532,7 +532,7 @@ public class FailureIT extends ITBaseImpl {
     try {
       // closing should detect the stale scan
       tx2.close();
-      Assert.assertFalse(true);
+      Assert.fail();
     } catch (StaleScanException sse) {
       // do nothing
     }
@@ -541,7 +541,7 @@ public class FailureIT extends ITBaseImpl {
 
     try {
       tx3.commit();
-      Assert.assertFalse(true);
+      Assert.fail();
     } catch (CommitException e) {
       // should not throw an exception
       tx3.close();

--- a/modules/integration-tests/src/main/java/org/apache/fluo/integration/impl/FaultyConfig.java
+++ b/modules/integration-tests/src/main/java/org/apache/fluo/integration/impl/FaultyConfig.java
@@ -65,7 +65,7 @@ public class FaultyConfig extends Environment {
         }
       }
 
-      if (writes.size() > 0) {
+      if (!writes.isEmpty()) {
         Iterator<Result> results = cw.write(writes.iterator());
 
         while (results.hasNext()) {


### PR DESCRIPTION
- Removed unnecessary interface modifiers
- Removed unnecessary calls to toString()
- Removed redundant local variables
- size() == 0 replaced with isEmpty()
- Simplified JUnit assertions
- Remove redundant imports from the same package
- Remove java.lang imports. They are imported by default.
- Remove unused import from FluoRemove 