### PR TITLE
Identify nofification scan as type in execution hint #1055

### DIFF
--- a/modules/core/src/main/java/org/apache/fluo/core/worker/finder/hash/ScanTask.java
+++ b/modules/core/src/main/java/org/apache/fluo/core/worker/finder/hash/ScanTask.java
@@ -57,6 +57,9 @@ public class ScanTask implements Runnable {
   private long minSleepTime;
   private long maxSleepTime;
 
+  private static final Map<String, String> SCAN_EXEC_HINTS =
+      Collections.singletonMap("scan_type", "fluo-ntfy");
+
   ScanTask(NotificationFinder finder, NotificationProcessor proccessor,
       PartitionManager partitionManager, Environment env, AtomicBoolean stopped, long minSleepTime,
       long maxSleepTime) {
@@ -190,6 +193,8 @@ public class ScanTask implements Runnable {
       IteratorSetting iterCfg = new IteratorSetting(30, "nhf", NotificationHashFilter.class);
       NotificationHashFilter.setModulusParams(iterCfg, pi.getMyGroupSize(), pi.getMyIdInGroup());
       scanner.addScanIterator(iterCfg);
+
+      scanner.setExecutionHints(SCAN_EXEC_HINTS);
 
       ScanCounts counts = new ScanCounts();
 


### PR DESCRIPTION
With these changes and the changes in apache/accumulo#972, the following accumulo config should run notification scans in their own executor.

```
config -s tserver.scan.executors.background.threads=1
config -t stresso -s table.scan.dispatcher=org.apache.accumulo.core.spi.scan.SimpleScanDispatcher
config -t stresso -s table.scan.dispatcher.opts.executor.fluo-ntfy=background
```