### PR TITLE
Parallelize TransactionImpl.readUnread()

### DIFF
--- a/modules/core/src/main/java/org/apache/fluo/core/impl/SnapshotScanner.java
+++ b/modules/core/src/main/java/org/apache/fluo/core/impl/SnapshotScanner.java
@@ -75,7 +75,6 @@ public class SnapshotScanner implements Iterable<Entry<Key, Value>> {
   private final Environment env;
   private final TxStats stats;
   private final Opts config;
-  private Consumer<Entry<Key, Value>> locksSeen;
 
   static final long INITIAL_WAIT_TIME = 50;
   // TODO make configurable
@@ -155,8 +154,6 @@ public class SnapshotScanner implements Iterable<Entry<Key, Value>> {
 
       // read ahead a little bit looking for other locks to resolve
 
-      locksSeen.accept(lockEntry);
-
       long startTime = System.currentTimeMillis();
       long waitTime = INITIAL_WAIT_TIME;
 
@@ -174,7 +171,6 @@ public class SnapshotScanner implements Iterable<Entry<Key, Value>> {
 
           if (ColumnType.from(entry.getKey()) == ColumnType.LOCK) {
             locks.add(entry);
-            locksSeen.accept(lockEntry);
           }
 
           amountRead += entry.getKey().getSize() + entry.getValue().getSize();
@@ -241,13 +237,11 @@ public class SnapshotScanner implements Iterable<Entry<Key, Value>> {
     }
   }
 
-  SnapshotScanner(Environment env, Opts config, long startTs, TxStats stats,
-      Consumer<Entry<Key, Value>> locksSeen) {
+  SnapshotScanner(Environment env, Opts config, long startTs, TxStats stats) {
     this.env = env;
     this.config = config;
     this.startTs = startTs;
     this.stats = stats;
-    this.locksSeen = locksSeen;
   }
 
   @Override


### PR DESCRIPTION
When a transaction only writes to a row+col and then has a collision
Fluo will read the row+col after the collision to look for orphaned
locks. This commit parallelizes this behavior by reading all row+cols
at once.

This commit accomplishes this by using a ParallelSnapshotScanner
instead of a SnapshotScanner. Since ParallelSnapshotScanner resolves
write locks in the implementation, the code to resolve write locks was
removed from reachUnread() and checkForOrphanedLocks().

Fixes #948