### PR TITLE
Add Oracle count functionality

### DIFF
--- a/modules/command/src/main/java/org/apache/fluo/command/FluoList.java
+++ b/modules/command/src/main/java/org/apache/fluo/command/FluoList.java
@@ -51,8 +51,8 @@ public class FluoList extends ConfigCommand {
 
       System.out.println("Fluo instance (" + config.getInstanceZookeepers() + ") contains "
           + children.size() + " application(s)\n");
-      System.out.println("Application     Status     # Workers");
-      System.out.println("-----------     ------     ---------");
+      System.out.println("Application     Status     # Workers     # Oracles");
+      System.out.println("-----------     ------     ---------     ---------");
 
       for (String path : children) {
         listApp(config, path);
@@ -91,7 +91,8 @@ public class FluoList extends ConfigCommand {
         state = "RUNNING";
       }
       int numWorkers = admin.numWorkers();
-      System.out.format("%-15s %-11s %4d\n", path, state, numWorkers);
+      int numOracles = admin.numOracles();
+      System.out.format("%-15s %-11s %4d %13d\n", path, state, numWorkers, numOracles);
     }
   }
 }

--- a/modules/command/src/main/java/org/apache/fluo/command/FluoOracle.java
+++ b/modules/command/src/main/java/org/apache/fluo/command/FluoOracle.java
@@ -19,8 +19,6 @@ import com.beust.jcommander.Parameters;
 import org.apache.fluo.api.client.FluoFactory;
 import org.apache.fluo.api.config.FluoConfiguration;
 import org.apache.fluo.core.util.UtilWaitThread;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @Parameters(commandNames = "oracle", commandDescription = "Starts Fluo Oracle process for <app>")
 public class FluoOracle extends AppCommand {

--- a/modules/core/src/main/java/org/apache/fluo/core/client/FluoAdminImpl.java
+++ b/modules/core/src/main/java/org/apache/fluo/core/client/FluoAdminImpl.java
@@ -39,6 +39,7 @@ import org.apache.accumulo.core.client.admin.NewTableConfiguration;
 import org.apache.accumulo.core.iterators.IteratorUtil;
 import org.apache.accumulo.core.iterators.IteratorUtil.IteratorScope;
 import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.recipes.leader.LeaderLatch;
 import org.apache.fluo.accumulo.iterators.GarbageCollectionIterator;
 import org.apache.fluo.accumulo.iterators.NotificationIterator;
 import org.apache.fluo.accumulo.summarizer.FluoSummarizer;
@@ -517,15 +518,16 @@ public class FluoAdminImpl implements FluoAdmin {
   }
 
   public static int numOracles(CuratorFramework curator) {
-    int numOracles = 0;
     if (oracleExists(curator)) {
       try {
-        numOracles += curator.getChildren().forPath(ZookeeperPath.ORACLE_SERVER).size();
+        LeaderLatch leaderLatch = new LeaderLatch(curator, ZookeeperPath.ORACLE_SERVER);
+        return leaderLatch.getParticipants().size();
       } catch (Exception e) {
         throw new RuntimeException(e);
       }
+    } else {
+      return 0;
     }
-    return numOracles;
   }
 
   public int numOracles() {

--- a/modules/core/src/main/java/org/apache/fluo/core/client/FluoAdminImpl.java
+++ b/modules/core/src/main/java/org/apache/fluo/core/client/FluoAdminImpl.java
@@ -516,6 +516,22 @@ public class FluoAdminImpl implements FluoAdmin {
     return oracleExists(getAppCurator());
   }
 
+  public static int numOracles(CuratorFramework curator) {
+    int numOracles = 0;
+    if (oracleExists(curator)) {
+      try {
+        numOracles += curator.getChildren().forPath(ZookeeperPath.ORACLE_SERVER).size();
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    }
+    return numOracles;
+  }
+
+  public int numOracles() {
+    return numOracles(getAppCurator());
+  }
+
   public static int numWorkers(CuratorFramework curator) {
     int numWorkers = 0;
     try {

--- a/modules/core/src/main/java/org/apache/fluo/core/client/FluoAdminImpl.java
+++ b/modules/core/src/main/java/org/apache/fluo/core/client/FluoAdminImpl.java
@@ -517,7 +517,8 @@ public class FluoAdminImpl implements FluoAdmin {
     return oracleExists(getAppCurator());
   }
 
-  public static int numOracles(CuratorFramework curator) {
+  public int numOracles() {
+    CuratorFramework curator = getAppCurator();
     if (oracleExists(curator)) {
       try {
         LeaderLatch leaderLatch = new LeaderLatch(curator, ZookeeperPath.ORACLE_SERVER);
@@ -528,10 +529,6 @@ public class FluoAdminImpl implements FluoAdmin {
     } else {
       return 0;
     }
-  }
-
-  public int numOracles() {
-    return numOracles(getAppCurator());
   }
 
   public static int numWorkers(CuratorFramework curator) {

--- a/modules/core/src/main/java/org/apache/fluo/core/oracle/OracleServer.java
+++ b/modules/core/src/main/java/org/apache/fluo/core/oracle/OracleServer.java
@@ -466,4 +466,9 @@ public class OracleServer implements OracleService.Iface, PathChildrenCacheListe
       log.warn("Oracle leadership watcher has been interrupted unexpectedly");
     }
   }
+
+  @VisibleForTesting
+  public void awaitLeaderElection(long timeout, TimeUnit timeUnit) throws InterruptedException {
+    leaderLatch.await(timeout, timeUnit);
+  }
 }

--- a/modules/integration-tests/src/main/java/org/apache/fluo/integration/client/FluoAdminImplIT.java
+++ b/modules/integration-tests/src/main/java/org/apache/fluo/integration/client/FluoAdminImplIT.java
@@ -265,4 +265,21 @@ public class FluoAdminImplIT extends ITBaseImpl {
     env2.close();
 
   }
+
+  @Test
+  public void testNumOracles() throws Exception {
+    try (FluoAdminImpl admin = new FluoAdminImpl(config)) {
+      Assert.assertEquals(1, admin.numOracles());
+
+      OracleServer oserver2 = new OracleServer(env);
+      oserver2.start();
+      Assert.assertEquals(2, admin.numOracles());
+
+      oserver2.stop();
+      Assert.assertEquals(1, admin.numOracles());
+
+      oserver.stop();
+      Assert.assertEquals(0, admin.numOracles());
+    }
+  }
 }

--- a/modules/integration-tests/src/main/java/org/apache/fluo/integration/client/FluoAdminImplIT.java
+++ b/modules/integration-tests/src/main/java/org/apache/fluo/integration/client/FluoAdminImplIT.java
@@ -18,6 +18,7 @@ package org.apache.fluo.integration.client;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 import com.google.common.collect.Iterables;
 import org.apache.accumulo.core.client.AccumuloClient;
@@ -273,12 +274,15 @@ public class FluoAdminImplIT extends ITBaseImpl {
 
       OracleServer oserver2 = new OracleServer(env);
       oserver2.start();
+      oserver2.awaitLeaderElection(3, TimeUnit.SECONDS);
       Assert.assertEquals(2, admin.numOracles());
 
       oserver2.stop();
+      oserver2.awaitLeaderElection(3, TimeUnit.SECONDS);
       Assert.assertEquals(1, admin.numOracles());
 
       oserver.stop();
+      oserver.awaitLeaderElection(3, TimeUnit.SECONDS);
       Assert.assertEquals(0, admin.numOracles());
     }
   }


### PR DESCRIPTION
Add functionality to FluoAdminImpl to count the number of Oracles
started. This allows the 'fluo list' command to print the number
of Oracles for each app.

Fixes #895