### PR TITLE
Use LeaderLatch to determine if oracle exists

### DIFF
--- a/modules/core/src/main/java/org/apache/fluo/core/client/FluoAdminImpl.java
+++ b/modules/core/src/main/java/org/apache/fluo/core/client/FluoAdminImpl.java
@@ -335,7 +335,6 @@ public class FluoAdminImpl implements FluoAdmin {
       CuratorFramework curator = getAppCurator();
       ObserverUtil.initialize(curator, config);
 
-
       sharedProps.store(baos, "Shared java props");
 
       CuratorUtil.putData(curator, ZookeeperPath.CONFIG_SHARED, baos.toByteArray(),
@@ -513,16 +512,12 @@ public class FluoAdminImpl implements FluoAdmin {
   }
 
   public static int numOracles(CuratorFramework curator) {
-    int numOracles = 0;
     try {
-      if (curator.checkExists().forPath(ZookeeperPath.ORACLE_SERVER) != null) {
-        LeaderLatch leaderLatch = new LeaderLatch(curator, ZookeeperPath.ORACLE_SERVER);
-        numOracles = leaderLatch.getParticipants().size();
-      }
+      LeaderLatch leaderLatch = new LeaderLatch(curator, ZookeeperPath.ORACLE_SERVER);
+      return leaderLatch.getParticipants().size();
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
-    return numOracles;
   }
 
   public int numOracles() {

--- a/modules/core/src/main/java/org/apache/fluo/core/client/FluoAdminImpl.java
+++ b/modules/core/src/main/java/org/apache/fluo/core/client/FluoAdminImpl.java
@@ -511,7 +511,7 @@ public class FluoAdminImpl implements FluoAdmin {
     return oracleExists(getAppCurator());
   }
 
-  public static int numOracles(CuratorFramework curator) {
+  private static int numOracles(CuratorFramework curator) {
     try {
       LeaderLatch leaderLatch = new LeaderLatch(curator, ZookeeperPath.ORACLE_SERVER);
       return leaderLatch.getParticipants().size();

--- a/modules/core/src/main/java/org/apache/fluo/core/client/FluoAdminImpl.java
+++ b/modules/core/src/main/java/org/apache/fluo/core/client/FluoAdminImpl.java
@@ -505,30 +505,28 @@ public class FluoAdminImpl implements FluoAdmin {
   }
 
   public static boolean oracleExists(CuratorFramework curator) {
-    try {
-      return curator.checkExists().forPath(ZookeeperPath.ORACLE_SERVER) != null
-          && !curator.getChildren().forPath(ZookeeperPath.ORACLE_SERVER).isEmpty();
-    } catch (Exception e) {
-      throw new RuntimeException(e);
-    }
+    return numOracles(curator) > 0;
   }
 
   public boolean oracleExists() {
     return oracleExists(getAppCurator());
   }
 
-  public int numOracles() {
-    CuratorFramework curator = getAppCurator();
-    if (oracleExists(curator)) {
-      try {
+  public static int numOracles(CuratorFramework curator) {
+    int numOracles = 0;
+    try {
+      if (curator.checkExists().forPath(ZookeeperPath.ORACLE_SERVER) != null) {
         LeaderLatch leaderLatch = new LeaderLatch(curator, ZookeeperPath.ORACLE_SERVER);
-        return leaderLatch.getParticipants().size();
-      } catch (Exception e) {
-        throw new RuntimeException(e);
+        numOracles = leaderLatch.getParticipants().size();
       }
-    } else {
-      return 0;
+    } catch (Exception e) {
+      throw new RuntimeException(e);
     }
+    return numOracles;
+  }
+
+  public int numOracles() {
+    return numOracles(getAppCurator());
   }
 
   public static int numWorkers(CuratorFramework curator) {

--- a/modules/mapreduce/src/main/java/org/apache/fluo/mapreduce/FluoOutputFormat.java
+++ b/modules/mapreduce/src/main/java/org/apache/fluo/mapreduce/FluoOutputFormat.java
@@ -43,8 +43,7 @@ public class FluoOutputFormat extends OutputFormat<Loader, NullWritable> {
   private static String PROPS_CONF_KEY = FluoOutputFormat.class.getName() + ".props";
 
   @Override
-  public void checkOutputSpecs(JobContext arg0) throws IOException, InterruptedException {
-  }
+  public void checkOutputSpecs(JobContext arg0) throws IOException, InterruptedException {}
 
   @Override
   public OutputCommitter getOutputCommitter(TaskAttemptContext arg0)


### PR DESCRIPTION
The old implementation of oracleExists checks to see if there are
more than 1 ZNodes under the ZookeeperPath.ORACLE_SERVER path. This
relies on the LeaderLatch implementation and uses a path given to
a Curator recipe, which is advised against by the Curator docs.
See https://cwiki.apache.org/confluence/display/CURATOR/TN7.

The new implementation utilizes LeaderLatch to count the number
of participants to see if there's more than 0.