### PR TITLE
Remove race condition from FluoAdminImpl.numWorkers

### DIFF
--- a/modules/core/src/main/java/org/apache/fluo/core/client/FluoAdminImpl.java
+++ b/modules/core/src/main/java/org/apache/fluo/core/client/FluoAdminImpl.java
@@ -527,13 +527,13 @@ public class FluoAdminImpl implements FluoAdmin {
   public static int numWorkers(CuratorFramework curator) {
     int numWorkers = 0;
     try {
-      if (curator.checkExists().forPath(ZookeeperPath.FINDERS) != null) {
-        for (String path : curator.getChildren().forPath(ZookeeperPath.FINDERS)) {
-          if (path.startsWith(PartitionManager.ZK_FINDER_PREFIX)) {
-            numWorkers++;
-          }
+      for (String path : curator.getChildren().forPath(ZookeeperPath.FINDERS)) {
+        if (path.startsWith(PartitionManager.ZK_FINDER_PREFIX)) {
+          numWorkers++;
         }
       }
+    } catch (KeeperException.NoNodeException e) {
+      return 0;
     } catch (Exception e) {
       throw new RuntimeException(e);
     }


### PR DESCRIPTION
The pattern of checking if a ZNode exists and then getting it's
children contains a race condition. If the ZNode is deleted after
the existence check but before getting the children then a
NoNodeException will be thrown instead of returning 0.

Instead we skip the existence check and just return 0 when a
NoNodeException is thrown. This will avoid the race condition.

Fixes #1089