### PR TITLE
Remove stack traces from Integration Test logs

### DIFF
--- a/modules/integration-tests/src/main/resources/log4j.properties
+++ b/modules/integration-tests/src/main/resources/log4j.properties
@@ -36,3 +36,5 @@ log4j.logger.org.apache.zookeeper.ClientCnxn=FATAL
 log4j.logger.org.apache.zookeeper.ZooKeeper=WARN
 log4j.logger.org.apache.curator.framework.recipes.cache.PathChildrenCache=FATAL
 log4j.logger.org.apache.fluo=ERROR
+log4j.logger.org.apache.fluo.core.oracle.OracleClient=FATAL
+log4j.logger.org.apache.fluo.core.shaded.thrift.ProcessFunction=FATAL


### PR DESCRIPTION
Expected errors during integartion tests were logging large
stack traces. This caused people to think there were errors in
the tests when there weren't and was ugly to look at.

The majority of the stack traces were coming from
org.apache.fluo.core.oracle.OracleClient and
org.apache.fluo.core.shaded.thrift.ProcessFunction. Setting these
loggers to FATAL prevents these stack traces from being logged.