### PR TITLE
Javadoc mistake in byteAt(int)

### DIFF
--- a/modules/api/src/main/java/org/apache/fluo/api/data/Bytes.java
+++ b/modules/api/src/main/java/org/apache/fluo/api/data/Bytes.java
@@ -98,7 +98,7 @@ public final class Bytes implements Comparable<Bytes>, Serializable {
    *
    * @param i index into sequence
    * @return byte
-   * @throws IllegalArgumentException if i is out of range
+   * @throws IndexOutOfBoundsException if i is out of range
    */
   public byte byteAt(int i) {
 


### PR DESCRIPTION
Fix documentation of type of exception thrown by byteAt.

The documentation states IllegalArgumentException is thrown if index is out of bound, while the thrown exception is IndexOutOfBoundsException.