### PR TITLE
Upload test logs on build failure

### DIFF
--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -52,18 +52,21 @@ jobs:
       env:
         MAVEN_OPTS: -Djansi.force=true
     - name: Upload unit test results
+      if: ${{ failure() }}
       uses: actions/upload-artifact@v2
       with:
         name: surefire-reports
         path: ./**/target/surefire-reports/
         if-no-files-found: ignore
     - name: Upload integration test results
+      if: ${{ failure() }}
       uses: actions/upload-artifact@v2
       with:
         name: failsafe-reports
         path: ./**/target/failsafe-reports/
         if-no-files-found: ignore
     - name: Upload mini test logs
+      if: ${{ failure() }}
       uses: actions/upload-artifact@v2
       with:
         name: mini-tests-logs


### PR DESCRIPTION
* Double the default timeout, to allow some slower tests to finish in
  the CI infrastructure