### PR TITLE
First pass at adding scan time authorizations to transactions/snapshots

### DIFF
--- a/modules/api/src/main/java/org/apache/fluo/api/client/FluoClient.java
+++ b/modules/api/src/main/java/org/apache/fluo/api/client/FluoClient.java
@@ -15,6 +15,8 @@
 
 package org.apache.fluo.api.client;
 
+import java.util.Collection;
+
 import org.apache.fluo.api.config.FluoConfiguration;
 import org.apache.fluo.api.config.SimpleConfiguration;
 import org.apache.fluo.api.metrics.MetricsReporter;

--- a/modules/api/src/main/java/org/apache/fluo/api/client/FluoClient.java
+++ b/modules/api/src/main/java/org/apache/fluo/api/client/FluoClient.java
@@ -15,8 +15,6 @@
 
 package org.apache.fluo.api.client;
 
-import java.util.Collection;
-
 import org.apache.fluo.api.config.FluoConfiguration;
 import org.apache.fluo.api.config.SimpleConfiguration;
 import org.apache.fluo.api.metrics.MetricsReporter;

--- a/modules/api/src/main/java/org/apache/fluo/api/client/Snapshot.java
+++ b/modules/api/src/main/java/org/apache/fluo/api/client/Snapshot.java
@@ -15,6 +15,8 @@
 
 package org.apache.fluo.api.client;
 
+import java.util.Collection;
+
 /**
  * Allows users to read from a Fluo table at a certain point in time. Snapshot extends
  * {@link SnapshotBase} to include a {@link #close} method which must be called when you are
@@ -29,4 +31,8 @@ public interface Snapshot extends SnapshotBase, AutoCloseable {
    */
   @Override
   void close();
+
+  default Snapshot useScanTimeAuthorizations(Collection<String> authz) {
+    return this;
+  }
 }

--- a/modules/api/src/main/java/org/apache/fluo/api/config/FluoConfiguration.java
+++ b/modules/api/src/main/java/org/apache/fluo/api/config/FluoConfiguration.java
@@ -514,6 +514,9 @@ public class FluoConfiguration extends SimpleConfiguration {
     throw new NoSuchElementException(ACCUMULO_PASSWORD_PROP + " is not set!");
   }
 
+  /**
+   * @since 2.0.0
+   */
   public FluoConfiguration setAccumuloAuthorizations(String... auths) {
     setProperties(ACCUMULO_AUTH_PROP, auths);
     return this;

--- a/modules/api/src/main/java/org/apache/fluo/api/config/FluoConfiguration.java
+++ b/modules/api/src/main/java/org/apache/fluo/api/config/FluoConfiguration.java
@@ -151,6 +151,9 @@ public class FluoConfiguration extends SimpleConfiguration {
    * @since 1.2.0
    */
   public static final String ACCUMULO_USER_PROP = ACCUMULO_PREFIX + ".user";
+
+  public static final String ACCUMULO_AUTH_PROP = ACCUMULO_PREFIX + ".auths";
+
   /**
    * @since 1.2.0
    */
@@ -486,6 +489,7 @@ public class FluoConfiguration extends SimpleConfiguration {
     return getDepNonEmptyString(ACCUMULO_USER_PROP, CLIENT_ACCUMULO_USER_PROP);
   }
 
+
   /**
    * Sets the Apache Accumulo password property {@value #ACCUMULO_PASSWORD_PROP}
    *
@@ -508,6 +512,19 @@ public class FluoConfiguration extends SimpleConfiguration {
       return verifyNotNull(CLIENT_ACCUMULO_PASSWORD_PROP, getString(CLIENT_ACCUMULO_PASSWORD_PROP));
     }
     throw new NoSuchElementException(ACCUMULO_PASSWORD_PROP + " is not set!");
+  }
+
+  public FluoConfiguration setAccumuloAuthorizations(String... auths) {
+    setProperties(ACCUMULO_AUTH_PROP, auths);
+    return this;
+  }
+
+  public String[] getAccumuloAuthorizations() {
+    if (containsKey(ACCUMULO_AUTH_PROP)) {
+      return this.getProperties(ACCUMULO_AUTH_PROP);
+    } else {
+      return new String[0];
+    }
   }
 
   /**

--- a/modules/api/src/main/java/org/apache/fluo/api/config/FluoConfiguration.java
+++ b/modules/api/src/main/java/org/apache/fluo/api/config/FluoConfiguration.java
@@ -522,7 +522,7 @@ public class FluoConfiguration extends SimpleConfiguration {
     return this;
   }
 
-    /**
+  /**
    * @since 2.0.0
    */
   public String[] getAccumuloAuthorizations() {

--- a/modules/api/src/main/java/org/apache/fluo/api/config/FluoConfiguration.java
+++ b/modules/api/src/main/java/org/apache/fluo/api/config/FluoConfiguration.java
@@ -519,6 +519,9 @@ public class FluoConfiguration extends SimpleConfiguration {
     return this;
   }
 
+    /**
+   * @since 2.0.0
+   */
   public String[] getAccumuloAuthorizations() {
     if (containsKey(ACCUMULO_AUTH_PROP)) {
       return this.getProperties(ACCUMULO_AUTH_PROP);

--- a/modules/api/src/main/java/org/apache/fluo/api/config/SimpleConfiguration.java
+++ b/modules/api/src/main/java/org/apache/fluo/api/config/SimpleConfiguration.java
@@ -30,6 +30,7 @@ import java.io.StringReader;
 import java.io.UncheckedIOException;
 import java.io.Writer;
 import java.nio.file.Files;
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -240,6 +241,27 @@ public class SimpleConfiguration implements Serializable {
 
   public void setProperty(String key, String value) {
     internalConfig.setProperty(key, value);
+  }
+
+  public void setProperties(String key, String... values) {
+    if (values == null) {
+      values = new String[0];
+    } else {
+      // don't let callers modify the array underneath of us
+      String[] copy = new String[values.length];
+      System.arraycopy(values, 0, copy, 0, copy.length);
+    }
+    internalConfig.setProperty(key, values);
+  }
+
+  public String[] getProperties(String key) {
+    // TODO fix cast class; use Properties?
+    ArrayList<String> values = (ArrayList<String>) internalConfig.getProperty(key);
+    if (values == null) {
+      return new String[0];
+    } else {
+      return values.toArray(new String[values.size()]);
+    }
   }
 
   /**

--- a/modules/api/src/main/java/org/apache/fluo/api/config/SimpleConfiguration.java
+++ b/modules/api/src/main/java/org/apache/fluo/api/config/SimpleConfiguration.java
@@ -247,12 +247,12 @@ public class SimpleConfiguration implements Serializable {
    * @since 2.0.0
    */
   public void setProperties(String key, String... values) {
-    if (values == null) {
-      values = new String[0];
-    } else {
-      // don't let callers modify the array underneath of us
-      String[] copy = new String[values.length];
-      System.arraycopy(values, 0, copy, 0, copy.length);
+    Objects.requireNonNull(values, "Values for key `" + key + "` must be non-null.");
+    // don't let callers modify the array underneath of us
+    String[] copy = new String[values.length];
+    System.arraycopy(values, 0, copy, 0, copy.length);
+    for (String value : copy) {
+      Objects.requireNonNull(value,"Encountered null value for key `" + key + "`.");
     }
     internalConfig.setProperty(key, values);
   }

--- a/modules/api/src/main/java/org/apache/fluo/api/config/SimpleConfiguration.java
+++ b/modules/api/src/main/java/org/apache/fluo/api/config/SimpleConfiguration.java
@@ -252,7 +252,7 @@ public class SimpleConfiguration implements Serializable {
     String[] copy = new String[values.length];
     System.arraycopy(values, 0, copy, 0, copy.length);
     for (String value : copy) {
-      Objects.requireNonNull(value,"Encountered null value for key `" + key + "`.");
+      Objects.requireNonNull(value, "Encountered null value for key `" + key + "`.");
     }
     internalConfig.setProperty(key, values);
   }

--- a/modules/command/src/test/java/org/apache/fluo/command/ScanTest.java
+++ b/modules/command/src/test/java/org/apache/fluo/command/ScanTest.java
@@ -16,6 +16,7 @@
 package org.apache.fluo.command;
 
 import com.beust.jcommander.JCommander;
+import org.apache.accumulo.core.security.Authorizations;
 import org.apache.fluo.api.data.Column;
 import org.apache.fluo.api.data.RowColumn;
 import org.apache.fluo.api.data.Span;
@@ -34,7 +35,8 @@ public class ScanTest {
     JCommander jcommand = new JCommander(scan);
     jcommand.parse(args.split(" "));
     ScanUtil.ScanOpts opts = scan.getScanOpts();
-    return new SnapshotScanner.Opts(ScanUtil.getSpan(opts), ScanUtil.getColumns(opts), false);
+    return new SnapshotScanner.Opts(ScanUtil.getSpan(opts), ScanUtil.getColumns(opts), false,
+        Authorizations.EMPTY);
   }
 
   @Test

--- a/modules/core/src/main/java/org/apache/fluo/core/client/FluoClientImpl.java
+++ b/modules/core/src/main/java/org/apache/fluo/core/client/FluoClientImpl.java
@@ -15,11 +15,14 @@
 
 package org.apache.fluo.core.client;
 
+import java.util.Collection;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.Iterables;
+import org.apache.accumulo.core.security.Authorizations;
 import org.apache.fluo.api.client.FluoClient;
 import org.apache.fluo.api.client.LoaderExecutor;
 import org.apache.fluo.api.client.Snapshot;

--- a/modules/core/src/main/java/org/apache/fluo/core/impl/Environment.java
+++ b/modules/core/src/main/java/org/apache/fluo/core/impl/Environment.java
@@ -18,10 +18,14 @@ package org.apache.fluo.core.impl;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.Map.Entry;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+import com.google.common.base.Splitter;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Maps;
 import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.TableNotFoundException;
@@ -100,6 +104,13 @@ public class Environment implements AutoCloseable {
     if (!client.instanceOperations().getInstanceId().canonical().equals(accumuloInstanceID)) {
       throw new IllegalArgumentException("unexpected accumulo instance id "
           + client.instanceOperations().getInstanceId() + " != " + accumuloInstanceID);
+    }
+
+    String[] auths = config.getAccumuloAuthorizations();
+    if (auths.length == 0) {
+      this.auths = new Authorizations();
+    } else {
+      this.auths = new Authorizations(auths);
     }
 
     try {

--- a/modules/core/src/main/java/org/apache/fluo/core/impl/scanner/ScannerBuilderImpl.java
+++ b/modules/core/src/main/java/org/apache/fluo/core/impl/scanner/ScannerBuilderImpl.java
@@ -21,6 +21,7 @@ import java.util.Objects;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
+import org.apache.accumulo.core.security.Authorizations;
 import org.apache.fluo.api.client.scanner.CellScanner;
 import org.apache.fluo.api.client.scanner.RowScannerBuilder;
 import org.apache.fluo.api.client.scanner.ScannerBuilder;
@@ -37,8 +38,15 @@ public class ScannerBuilderImpl implements ScannerBuilder {
   private Span span = EMPTY_SPAN;
   private Collection<Column> columns = Collections.emptyList();
 
+  private Authorizations scanTimeAuthz = Authorizations.EMPTY;
+
   public ScannerBuilderImpl(TransactionImpl tx) {
     this.tx = tx;
+  }
+
+  public ScannerBuilderImpl(TransactionImpl tx, Authorizations scanTimeAuthz) {
+    this.tx = tx;
+    this.scanTimeAuthz = scanTimeAuthz;
   }
 
   @Override
@@ -70,9 +78,19 @@ public class ScannerBuilderImpl implements ScannerBuilder {
     return this;
   }
 
+  public ScannerBuilder withLabels(Collection<String> authLables) {
+    Objects.requireNonNull(authLables);
+    if (authLables.isEmpty()) {
+      this.scanTimeAuthz = Authorizations.EMPTY;
+    } else {
+      this.scanTimeAuthz = new Authorizations(authLables.toArray(new String[authLables.size()]));
+    }
+    return this;
+  }
+
   @Override
   public CellScanner build() {
-    SnapshotScanner snapScanner = tx.newSnapshotScanner(span, columns);
+    SnapshotScanner snapScanner = tx.newSnapshotScanner(span, columns, scanTimeAuthz);
     return new CellScannerImpl(snapScanner, columns);
   }
 

--- a/modules/integration-tests/src/main/java/org/apache/fluo/integration/client/FluoClientAuthorizationsIT.java
+++ b/modules/integration-tests/src/main/java/org/apache/fluo/integration/client/FluoClientAuthorizationsIT.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.fluo.integration.client;
+
+import java.util.Collections;
+import java.util.Map;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.accumulo.core.client.AccumuloClient;
+import org.apache.accumulo.core.security.Authorizations;
+import org.apache.fluo.api.client.FluoClient;
+import org.apache.fluo.api.client.FluoFactory;
+import org.apache.fluo.api.client.Snapshot;
+import org.apache.fluo.api.client.Transaction;
+import org.apache.fluo.api.config.FluoConfiguration;
+import org.apache.fluo.api.data.Column;
+import org.apache.fluo.api.exceptions.CommitException;
+import org.apache.fluo.core.util.AccumuloUtil;
+import org.apache.fluo.integration.ITBaseImpl;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class FluoClientAuthorizationsIT extends ITBaseImpl {
+  @Rule
+  public Timeout globalTimeout = Timeout.seconds(getTestTimeout());
+
+  Column ssn = new Column("", "ssn", "PRIVATE");
+  Column name = new Column("", "name", "PUBLIC");
+  Column id = new Column("", "id");
+  FluoConfiguration conf;
+  FluoClient client;
+
+  @Before
+  public void setupAuthorizations() throws Throwable {
+    try (AccumuloClient accumulo = AccumuloUtil.getClient(config)) {
+      accumulo.securityOperations().changeUserAuthorizations(config.getAccumuloUser(),
+          new Authorizations("PRIVATE", "PUBLIC"));
+    }
+    this.conf = new FluoConfiguration(config);
+    this.conf.setAccumuloAuthorizations("PRIVATE", "PUBLIC");
+    this.client = FluoFactory.newClient(this.conf);
+
+    writeSampleData();
+  }
+
+  /*
+   * Kind of sloppy because we assert some basic write functionality already works. However, this
+   * lets us re-use and organize tests that read this data better.
+   */
+  public void writeSampleData() {
+    try (Transaction txn = client.newTransaction()) {
+      txn.set("bill", ssn, "000-00-0001");
+      txn.set("bill", name, "william");
+      txn.set("bill", id, "1");
+      txn.set("bob", ssn, "000-00-0002");
+      txn.set("bob", name, "robert");
+      txn.set("bob", id, "2");
+      txn.commit();
+    }
+  }
+
+  @After
+  public void cleanupClient() throws Throwable {
+    this.client.close();
+  }
+
+  @Test
+  public void testBasicRead() {
+    try (Snapshot snapshot = client.newSnapshot()) {
+      Map<Column, String> bill = snapshot.gets("bill");
+      assertTrue(bill.containsKey(name));
+      assertTrue(bill.containsKey(ssn));
+      assertTrue(bill.containsKey(id));
+      Map<Column, String> bob = snapshot.gets("bill");
+      assertTrue(bob.containsKey(name));
+      assertTrue(bob.containsKey(ssn));
+      assertTrue(bob.containsKey(id));
+    }
+  }
+
+  @Test
+  public void testPublicRead() {
+    try (Snapshot snapshot =
+        client.newSnapshot().useScanTimeAuthorizations(ImmutableList.of("PUBLIC"))) {
+      Map<Column, String> bill = snapshot.gets("bill");
+      assertTrue(bill.containsKey(name));
+      assertTrue(bill.containsKey(id));
+      assertEquals(2, bill.size());
+    }
+  }
+
+  @Test
+  public void testPrivateRead() {
+    try (Snapshot snapshot =
+        client.newSnapshot().useScanTimeAuthorizations(ImmutableList.of("PRIVATE"))) {
+      Map<Column, String> bill = snapshot.gets("bill");
+      assertTrue(bill.containsKey(ssn));
+      assertTrue(bill.containsKey(id));
+      assertEquals(2, bill.size());
+    }
+  }
+
+  // had some initial uses where I checked for Authorizations.EMPTY instead of null
+  // or empty set of auths, which caused the underlying scanner to scan at max
+  // authorizations. I want this call to explicitly say "only read data that is
+  // unlabeled"
+  @Test
+  public void testScanningWithNoAuths() {
+    try (Snapshot snapshot =
+        client.newSnapshot().useScanTimeAuthorizations(Collections.emptySet())) {
+      Map<Column, String> bill = snapshot.gets("bill");
+      assertFalse(bill.containsKey(name));
+      assertFalse(bill.containsKey(ssn));
+      assertTrue(bill.containsKey(id));
+      Map<Column, String> bob = snapshot.gets("bob");
+      assertFalse(bob.containsKey(name));
+      assertFalse(bob.containsKey(ssn));
+      assertTrue(bob.containsKey(id));
+    }
+  }
+
+  @Test(expected = CommitException.class)
+  public void testWriteUnreadable() {
+    try (Transaction txn = client.newTransaction()) {
+      txn.set("bill", new Column("", "unreadable", "UNREADABLE"), "value");
+      txn.commit();
+    }
+  }
+}


### PR DESCRIPTION
Rough cut of this. Needs to fix documentation, and add assertion to the tests. Open to suggestions on better test cases.

This PR adds support for the following:

1. Specifying authentication tokens to use with the `FluoClient` on construction.
2. Specifying authentication tokens to use with a `Snapshot` when performing a read.

I also think it makes sense to ensure the fluo table has the constraint set on it so unreadable data can't be written. Currently the behavior I'd see in my simple test is Fluo would kick back an error about a failed transaction because it couldn't read the data back. I think the better behavior (as Keith suggested) would be avoid any confusion in that case and kick back a "hey this data violates a table constraint due to its visibilities" error. 