### PR TITLE
Fixes bug resolving lock w/ empty col fam. Reported in #660

### DIFF
--- a/modules/api/src/main/java/org/apache/fluo/api/data/Column.java
+++ b/modules/api/src/main/java/org/apache/fluo/api/data/Column.java
@@ -28,11 +28,15 @@ import java.util.Objects;
 public final class Column implements Comparable<Column>, Serializable {
 
   private static final long serialVersionUID = 1L;
-  private static final Bytes UNSET = Bytes.of(new byte[0]);
 
-  private Bytes family = UNSET;
-  private Bytes qualifier = UNSET;
-  private Bytes visibility = UNSET;
+  private final Bytes family;
+  private final Bytes qualifier;
+  private final Bytes visibility;
+
+  private final boolean isFamilySet;
+  private final boolean isQualifierSet;
+  private final boolean isVisibilitySet;
+
   private int hashCode = 0;
 
   public static final Column EMPTY = new Column();
@@ -40,7 +44,14 @@ public final class Column implements Comparable<Column>, Serializable {
   /**
    * Creates an empty Column where family, qualifier and visibility are not set
    */
-  public Column() {}
+  public Column() {
+    this.family = Bytes.EMPTY;
+    this.isFamilySet = false;
+    this.qualifier = Bytes.EMPTY;
+    this.isQualifierSet = false;
+    this.visibility = Bytes.EMPTY;
+    this.isVisibilitySet = false;
+  }
 
   /**
    * Creates Column with only a family.
@@ -48,6 +59,11 @@ public final class Column implements Comparable<Column>, Serializable {
   public Column(Bytes family) {
     Objects.requireNonNull(family, "Family must not be null");
     this.family = family;
+    this.isFamilySet = true;
+    this.qualifier = Bytes.EMPTY;
+    this.isQualifierSet = false;
+    this.visibility = Bytes.EMPTY;
+    this.isVisibilitySet = false;
   }
 
   /**
@@ -64,7 +80,11 @@ public final class Column implements Comparable<Column>, Serializable {
     Objects.requireNonNull(family, "Family must not be null");
     Objects.requireNonNull(qualifier, "Qualifier must not be null");
     this.family = family;
+    this.isFamilySet = true;
     this.qualifier = qualifier;
+    this.isQualifierSet = true;
+    this.visibility = Bytes.EMPTY;
+    this.isVisibilitySet = false;
   }
 
   /**
@@ -82,8 +102,11 @@ public final class Column implements Comparable<Column>, Serializable {
     Objects.requireNonNull(qualifier, "Qualifier must not be null");
     Objects.requireNonNull(visibility, "Visibility must not be null");
     this.family = family;
+    this.isFamilySet = true;
     this.qualifier = qualifier;
+    this.isQualifierSet = true;
     this.visibility = visibility;
+    this.isVisibilitySet = true;
   }
 
   /**
@@ -98,16 +121,13 @@ public final class Column implements Comparable<Column>, Serializable {
    * Returns true if family is set
    */
   public boolean isFamilySet() {
-    return family != UNSET;
+    return isFamilySet;
   }
 
   /**
    * Retrieves Column Family (in Bytes). Returns Bytes.EMPTY if not set.
    */
   public Bytes getFamily() {
-    if (!isFamilySet()) {
-      return Bytes.EMPTY;
-    }
     return family;
   }
 
@@ -122,16 +142,13 @@ public final class Column implements Comparable<Column>, Serializable {
    * Returns true if qualifier is set
    */
   public boolean isQualifierSet() {
-    return qualifier != UNSET;
+    return isQualifierSet;
   }
 
   /**
    * Retrieves Column Qualifier (in Bytes). Returns Bytes.EMPTY if not set.
    */
   public Bytes getQualifier() {
-    if (!isQualifierSet()) {
-      return Bytes.EMPTY;
-    }
     return qualifier;
   }
 
@@ -146,16 +163,13 @@ public final class Column implements Comparable<Column>, Serializable {
    * Returns true if visibility is set.
    */
   public boolean isVisibilitySet() {
-    return visibility != UNSET;
+    return isVisibilitySet;
   }
 
   /**
    * Retrieves Column Visibility (in Bytes). Returns Bytes.EMPTY if not set.
    */
   public Bytes getVisibility() {
-    if (!isVisibilitySet()) {
-      return Bytes.EMPTY;
-    }
     return visibility;
   }
 

--- a/modules/api/src/test/java/org/apache/fluo/api/data/ColumnTest.java
+++ b/modules/api/src/test/java/org/apache/fluo/api/data/ColumnTest.java
@@ -15,6 +15,9 @@
 
 package org.apache.fluo.api.data;
 
+import java.util.Arrays;
+import java.util.List;
+
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -73,6 +76,33 @@ public class ColumnTest {
     Assert.assertEquals(Bytes.of("cq3"), col.getQualifier());
     Assert.assertEquals(Bytes.of("cv3"), col.getVisibility());
     Assert.assertEquals(new Column("cf3", "cq3", "cv3"), col);
+
+    // an empty string should always be considered as set, try diff combos of empty and non empty
+    // strings.
+    for (String fam : Arrays.asList("", "f")) {
+      for (String qual : Arrays.asList("", "q")) {
+        for (String vis : Arrays.asList("", "v")) {
+          col = new Column(fam, qual, vis);
+          Assert.assertTrue(col.isFamilySet());
+          Assert.assertTrue(col.isQualifierSet());
+          Assert.assertTrue(col.isVisibilitySet());
+          Assert.assertEquals(Bytes.of(fam), col.getFamily());
+          Assert.assertEquals(Bytes.of(qual), col.getQualifier());
+          Assert.assertEquals(Bytes.of(vis), col.getVisibility());
+          Assert.assertEquals(new Column(fam, qual, vis), col);
+        }
+      }
+    }
+
+    col = new Column("", "", "");
+    Assert.assertTrue(col.isFamilySet());
+    Assert.assertTrue(col.isQualifierSet());
+    Assert.assertTrue(col.isVisibilitySet());
+    Assert.assertEquals(Bytes.of(""), col.getFamily());
+    Assert.assertEquals(Bytes.of(""), col.getQualifier());
+    Assert.assertEquals(Bytes.of(""), col.getVisibility());
+    Assert.assertEquals(new Column("", "", ""), col);
+
   }
 
   @Test


### PR DESCRIPTION
There was a bug where if a column family was empty and the qual was not empty this would cause lock recovery to fail.  The underlying cause was a bug in the Column class.  This class has an isFamilySet() method that was returning false when the family was set to the empty string.  This cause caused lock recovery code to create an incorrect range.

The Column class was relying on internal behavior of the Bytes class that probably changed and caused this bug.

This commit adds a new IT that recreates this bug.  If the new IT is run w/o the fix to the Column class then it would fail as follows.

```
Running org.apache.fluo.integration.impl.FailureIT
Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 8.011 sec <<< FAILURE! - in org.apache.fluo.integration.impl.FailureIT
testRecoverEmptyColumn(org.apache.fluo.integration.impl.FailureIT)  Time elapsed: 7.096 sec  <<< ERROR!
java.lang.IllegalStateException: can not abort : bob  bal  5 (UNKNOWN)
	at org.apache.fluo.integration.impl.FailureIT.testRecoverEmptyColumn(FailureIT.java:688)
```